### PR TITLE
Modified import logic to align with upstream and support visionOS

### DIFF
--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -15,11 +15,11 @@
 import Crypto
 import Dispatch
 import NIOCore
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if canImport(Darwin)
 import Darwin
 #else
 import Glibc
-#endif // os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#endif // canImport(Darwin)
 
 /// A `NIOSSHCertifiedPublicKey` is an SSH public key combined with an SSH certificate.
 ///


### PR DESCRIPTION
The way the import clause was formulated made it fail on visionOS. I checked upstream and they fixed it with a `#if canImport(Darwin)` macro, so I've added it here too, and it seems to fix all the problems, and now it builds fine for visionOS too.