### PR TITLE
Change all compiler directives to support visionOS

### DIFF
--- a/Sources/NIOSSH/CSPRNG/CSPRNG.swift
+++ b/Sources/NIOSSH/CSPRNG/CSPRNG.swift
@@ -31,7 +31,7 @@ struct CSPRNG: RandomNumberGenerator {
     private var baseRNG: SystemRandomNumberGenerator
 
     init() {
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(Linux) || os(Android)
+        #if canImport(Darwin) || os(Linux) || os(Android)
         self.baseRNG = SystemRandomNumberGenerator()
         #else
         fatalError("Platform does not have a supported CSPRNG")

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
@@ -50,7 +50,7 @@ public struct NIOSSHPrivateKey {
         self.backingKey = .custom(key)
     }
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    #if canImport(Darwin)
     public init(secureEnclaveP256Key key: SecureEnclave.P256.Signing.PrivateKey) {
         self.backingKey = .secureEnclaveP256(key)
     }
@@ -69,7 +69,7 @@ public struct NIOSSHPrivateKey {
             return ["ecdsa-sha2-nistp521"]
         case .custom(let backingKey):
             return [Substring(backingKey.keyPrefix)]
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if canImport(Darwin)
         case .secureEnclaveP256:
             return ["ecdsa-sha2-nistp256"]
         #endif
@@ -86,7 +86,7 @@ extension NIOSSHPrivateKey {
         case ecdsaP521(P521.Signing.PrivateKey)
         case custom(NIOSSHPrivateKeyProtocol)
 
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if canImport(Darwin)
         case secureEnclaveP256(SecureEnclave.P256.Signing.PrivateKey)
         #endif
     }
@@ -121,7 +121,7 @@ extension NIOSSHPrivateKey {
             }
             return NIOSSHSignature(backingSignature: .custom(signature))
 
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if canImport(Darwin)
         case .secureEnclaveP256(let key):
             let signature = try digest.withUnsafeBytes { ptr in
                 try key.signature(for: ptr)
@@ -148,7 +148,7 @@ extension NIOSSHPrivateKey {
         case .custom(let key):
             let signature = try key.signature(for: payload.bytes.readableBytesView)
             return NIOSSHSignature(backingSignature: .custom(signature))
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if canImport(Darwin)
         case .secureEnclaveP256(let key):
             let signature = try key.signature(for: payload.bytes.readableBytesView)
             return NIOSSHSignature(backingSignature: .ecdsaP256(signature))
@@ -171,7 +171,7 @@ public extension NIOSSHPrivateKey {
             return NIOSSHPublicKey(backingKey: .ecdsaP521(privateKey.publicKey))
         case .custom(let privateKey):
             return NIOSSHPublicKey(backingKey: .custom(privateKey.publicKey))
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if canImport(Darwin)
         case .secureEnclaveP256(let privateKey):
             return NIOSSHPublicKey(backingKey: .ecdsaP256(privateKey.publicKey))
         #endif

--- a/Tests/NIOSSHTests/EndToEndTests.swift
+++ b/Tests/NIOSSHTests/EndToEndTests.swift
@@ -830,7 +830,7 @@ class EndToEndTests: XCTestCase {
     func testSecureEnclaveKeys() throws {
         // This is a quick end-to-end test that validates that we support secure enclave private keys
         // on appropriate platforms.
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if canImport(Darwin)
         // If we can't create this key, we skip the test.
         let key: NIOSSHPrivateKey
         do {


### PR DESCRIPTION
This is a continuation of PR https://github.com/Joannis/swift-nio-ssh/pull/5.
I have missed out a few spots where upstream was taking into account visionOS, so I went through them all now and tried to fix them.