### PR TITLE
Modified PublicKey, Signature, and PrivateKey to support multiple prefixes

### DIFF
--- a/Sources/NIOSSH/Key Exchange/SSHKeyExchangeStateMachine.swift
+++ b/Sources/NIOSSH/Key Exchange/SSHKeyExchangeStateMachine.swift
@@ -251,9 +251,8 @@ struct SSHKeyExchangeStateMachine {
         case .keyExchangeInitSent(exchange: var exchanger, negotiated: let negotiated):
             switch self.role {
             case .client:
-                guard message.hostKey.keyPrefix.elementsEqual(negotiated.negotiatedHostKeyAlgorithm.utf8) else {
-                    throw NIOSSHError.invalidHostKeyForKeyExchange(expected: negotiated.negotiatedHostKeyAlgorithm,
-                                                                   got: message.hostKey.keyPrefix)
+                    guard message.hostKey.keyPrefixes.contains(where: { $0.elementsEqual(negotiated.negotiatedHostKeyAlgorithm.utf8) }) else {
+                    throw NIOSSHError.invalidHostKeyForKeyExchange(expected: negotiated.negotiatedHostKeyAlgorithm, got: message.hostKey.keyPrefixes)
                 }
 
                 let result = try exchanger.receiveServerKeyExchangePayload(
@@ -523,7 +522,7 @@ extension SSHKeyExchangeStateMachine {
 
     static var supportedServerHostKeyAlgorithms: [Substring] {
         let bundledAlgorithms = bundledServerHostKeyAlgorithms
-        let customAlgorithms = NIOSSHPublicKey.customPublicKeyAlgorithms.map { Substring($0.publicKeyPrefix) }
+        let customAlgorithms = NIOSSHPublicKey.customPublicKeyAlgorithms.flatMap { $0.publicKeyPrefixes.map { Substring($0) } }
 
         return bundledAlgorithms + customAlgorithms
     }

--- a/Sources/NIOSSH/Keys And Signatures/CustomKeys.swift
+++ b/Sources/NIOSSH/Keys And Signatures/CustomKeys.swift
@@ -21,12 +21,12 @@ import NIO
 ///
 /// - See: https://en.wikipedia.org/wiki/Digital_signature
 public protocol NIOSSHSignatureProtocol {
-    /// An identifier that represents the type of signature used in an SSH packet.
-    /// This identifier MUST be unique to the signature implementation.
-    /// The returned value MUST NOT overlap with other signature implementations or a specifications that the signature does not implement.
-    static var signaturePrefix: String { get }
-
-    /// The raw reprentation of this signature as a blob.
+    /// Identifiers that represent the types of signatures used in an SSH packet.
+    /// These identifiers MUST be unique to the signature implementation.
+    /// The returned values MUST NOT overlap with other signature implementations or specifications that the signature does not implement.
+    static var signaturePrefixes: [String] { get }
+    
+    /// The raw representation of this signature as a blob.
     var rawRepresentation: Data { get }
 
     /// Serializes and writes the signature to the buffer. The calling function SHOULD NOT keep track of the size of the written blob.
@@ -38,18 +38,18 @@ public protocol NIOSSHSignatureProtocol {
 }
 
 internal extension NIOSSHSignatureProtocol {
-    var signaturePrefix: String {
-        Self.signaturePrefix
+    var signaturePrefixes: [String] {
+        Self.signaturePrefixes
     }
 }
 
 public protocol NIOSSHPublicKeyProtocol {
-    /// An identifier that represents the type of public key used in an SSH packet.
-    /// This identifier MUST be unique to the public key implementation.
-    /// The returned value MUST NOT overlap with other public key implementations or a specifications that the public key does not implement.
-    static var publicKeyPrefix: String { get }
-
-    /// The raw reprentation of this publc key as a blob.
+    /// Identifiers that represent the types of public keys used in an SSH packet.
+    /// These identifiers MUST be unique to the public key implementation.
+    /// The returned values MUST NOT overlap with other public key implementations or specifications that the public key does not implement.
+    static var publicKeyPrefixes: [String] { get }
+    
+    /// The raw representation of this public key as a blob.
     var rawRepresentation: Data { get }
 
     /// Verifies that `signature` is the result of signing `data` using the private key that this public key is derived from.
@@ -64,17 +64,17 @@ public protocol NIOSSHPublicKeyProtocol {
 }
 
 internal extension NIOSSHPublicKeyProtocol {
-    var publicKeyPrefix: String {
-        Self.publicKeyPrefix
+    var publicKeyPrefixes: [String] {
+        Self.publicKeyPrefixes
     }
 }
 
 public protocol NIOSSHPrivateKeyProtocol {
-    /// An identifier that represents the type of private key used in an SSH packet.
-    /// This identifier MUST be unique to the private key implementation.
-    /// The returned value MUST NOT overlap with other private key implementations or a specifications that the private key does not implement.
-    static var keyPrefix: String { get }
-
+    /// Identifiers that represent the types of private keys used in an SSH packet.
+    /// These identifiers MUST be unique to the private key implementation.
+    /// The returned values MUST NOT overlap with other private key implementations or specifications that the private key does not implement.
+    static var keyPrefixes: [String] { get }
+    
     /// A public key instance that is able to verify signatures that are created using this private key.
     var publicKey: NIOSSHPublicKeyProtocol { get }
 
@@ -83,7 +83,7 @@ public protocol NIOSSHPrivateKeyProtocol {
 }
 
 internal extension NIOSSHPrivateKeyProtocol {
-    var keyPrefix: String {
-        Self.keyPrefix
+    var keyPrefixes: [String] {
+        Self.keyPrefixes
     }
 }

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -322,20 +322,20 @@ extension NIOSSHCertifiedPublicKey {
 
     static let ed25519KeyPrefix = "ssh-ed25519-cert-v01@openssh.com".utf8
 
-    internal var keyPrefix: String.UTF8View {
+    internal var keyPrefixes: [String.UTF8View] {
         switch self.key.backingKey {
         case .ed25519:
-            return Self.ed25519KeyPrefix
+            return [Self.ed25519KeyPrefix]
         case .ecdsaP256:
-            return Self.p256KeyPrefix
+            return [Self.p256KeyPrefix]
         case .ecdsaP384:
-            return Self.p384KeyPrefix
+            return [Self.p384KeyPrefix]
         case .ecdsaP521:
-            return Self.p521KeyPrefix
+            return [Self.p521KeyPrefix]
         case .certified:
             preconditionFailure("base key cannot be certified")
         case .custom(let custom):
-            return custom.publicKeyPrefix.utf8
+            return custom.publicKeyPrefixes.map { $0.utf8 }
         }
     }
 

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
@@ -68,7 +68,7 @@ public struct NIOSSHPrivateKey {
         case .ecdsaP521:
             return ["ecdsa-sha2-nistp521"]
         case .custom(let backingKey):
-            return [Substring(backingKey.keyPrefix)]
+            return backingKey.keyPrefixes.map { Substring($0) }
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256:
             return ["ecdsa-sha2-nistp256"]

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHSignature.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHSignature.swift
@@ -115,7 +115,7 @@ extension NIOSSHSignature.BackingSignature: Hashable {
             hasher.combine(sig.rawRepresentation)
         case .custom(let sig):
             hasher.combine(4)
-            hasher.combine(sig.signaturePrefix)
+            hasher.combine(sig.signaturePrefixes)
             hasher.combine(sig.rawRepresentation)
         }
     }
@@ -235,9 +235,11 @@ extension ByteBuffer {
                 return try buffer.readECDSAP521Signature()
             } else {
                 for signature in NIOSSHPublicKey.customSignatures {
-                    if bytesView.elementsEqual(signature.signaturePrefix.utf8) {
-                        let signature = try signature.read(from: &buffer)
-                        return NIOSSHSignature(backingSignature: .custom(signature))
+                    for prefix in signature.signaturePrefixes {
+                        if bytesView.elementsEqual(prefix.utf8) {
+                            let signature = try signature.read(from: &buffer)
+                            return NIOSSHSignature(backingSignature: .custom(signature))
+                        }
                     }
                 }
 

--- a/Sources/NIOSSH/NIOSSHError.swift
+++ b/Sources/NIOSSH/NIOSSHError.swift
@@ -127,8 +127,8 @@ extension NIOSSHError {
     }
 
     @inline(never)
-    internal static func invalidHostKeyForKeyExchange(expected: Substring, got actual: String.UTF8View) -> NIOSSHError {
-        NIOSSHError(type: .invalidHostKeyForKeyExchange, diagnostics: "Expected \(String(expected)), got \(String(actual))")
+    internal static func invalidHostKeyForKeyExchange(expected: Substring, got actual: [String.UTF8View]) -> NIOSSHError {
+        NIOSSHError(type: .invalidHostKeyForKeyExchange, diagnostics: "Expected \(String(expected)), got \(actual)")
     }
 
     @inline(never)

--- a/Sources/NIOSSH/SSHMessages.swift
+++ b/Sources/NIOSSH/SSHMessages.swift
@@ -691,7 +691,7 @@ extension ByteBuffer {
                         return nil
                     }
 
-                    guard algorithmName.readableBytesView.elementsEqual(publicKey.keyPrefix) else {
+                    guard publicKey.keyPrefixes.contains(where: { $0.elementsEqual(algorithmName.readableBytesView) }) else {
                         throw NIOSSHError.invalidSSHMessage(reason: "algorithm and key mismatch in user auth request")
                     }
 
@@ -765,7 +765,7 @@ extension ByteBuffer {
             }
 
             // Validate consistency here.
-            guard publicKeyType.readableBytesView.elementsEqual(publicKey.keyPrefix) else {
+            guard publicKey.keyPrefixes.contains(where: { $0.elementsEqual(publicKeyType.readableBytesView) }) else {
                 throw NIOSSHError.invalidSSHMessage(reason: "inconsistent key type")
             }
 


### PR DESCRIPTION
Modified protocols and classes for PublicKey, Signature, and PrivateKey to support multiple prefixes
SSHKeyExchangeStateMachine now checks if the hostKey prefixes contains the negotiated host key algorithm