### PR TITLE
feat: Update Swift tools to 5.10 and sync with swift-nio-ssh upstream v0.11.0 while preserving existing customizations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
@@ -15,6 +15,24 @@
 
 import PackageDescription
 
+let strictConcurrencyDevelopment = false
+
+let strictConcurrencySettings: [SwiftSetting] = {
+    var initialSettings: [SwiftSetting] = []
+    initialSettings.append(contentsOf: [
+        .enableUpcomingFeature("StrictConcurrency"),
+        .enableUpcomingFeature("InferSendableFromCaptures"),
+    ])
+
+    if strictConcurrencyDevelopment {
+        // -warnings-as-errors here is a workaround so that IDE-based development can
+        // get tripped up on -require-explicit-sendable.
+        initialSettings.append(.unsafeFlags(["-Xfrontend", "-require-explicit-sendable", "-warnings-as-errors"]))
+    }
+
+    return initialSettings
+}()
+
 let package = Package(
     name: "swift-nio-ssh",
     platforms: [
@@ -24,11 +42,11 @@ let package = Package(
         .tvOS(.v13),
     ],
     products: [
-        .library(name: "NIOSSH", targets: ["NIOSSH"]),
+        .library(name: "NIOSSH", targets: ["NIOSSH"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"4.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
@@ -41,7 +59,8 @@ let package = Package(
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "Atomics", package: "swift-atomics"),
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOSSHClient",
@@ -78,7 +97,23 @@ let package = Package(
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
     ]
 )
+
+// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
+for target in package.targets {
+    switch target.type {
+    case .regular, .test, .executable:
+        var settings = target.swiftSettings ?? []
+        // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+        settings.append(.enableUpcomingFeature("MemberImportVisibility"))
+        target.swiftSettings = settings
+    case .macro, .plugin, .system, .binary:
+        ()  // not applicable
+    @unknown default:
+        ()  // we don't know what to do here, do nothing
+    }
+}

--- a/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOCore
+
 protocol AcceptsUserAuthMessages {
     var userAuthStateMachine: UserAuthenticationStateMachine { get set }
 

--- a/Sources/NIOSSH/Key Exchange/EllipticCurveKeyExchange.swift
+++ b/Sources/NIOSSH/Key Exchange/EllipticCurveKeyExchange.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+import Foundation
 import NIOCore
 import NIOFoundationCompat
 

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -14,6 +14,7 @@
 
 import Crypto
 import Dispatch
+import Foundation
 import NIOCore
 #if canImport(Darwin)
 import Darwin

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+import Foundation
 import NIOCore
 
 /// An SSH private key.

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKey.swift
@@ -16,6 +16,7 @@ import Crypto
 import Foundation
 import NIOConcurrencyHelpers
 import NIOCore
+import NIOFoundationCompat
 
 /// An SSH public key.
 ///
@@ -282,13 +283,13 @@ internal var customKeyExchangeAlgorithms: [NIOSSHKeyExchangeAlgorithmProtocol.Ty
 }
 
 private enum _CustomAlgorithms {
-    static var transportProtectionSchemesLock = Lock()
+    static var transportProtectionSchemesLock = NIOLock()
     static var transportProtectionSchemes = [NIOSSHTransportProtection.Type]()
-    static var keyExchangeAlgorithmsLock = Lock()
+    static var keyExchangeAlgorithmsLock = NIOLock()
     static var keyExchangeAlgorithms = [NIOSSHKeyExchangeAlgorithmProtocol.Type]()
-    static var publicKeyAlgorithmsLock = Lock()
+    static var publicKeyAlgorithmsLock = NIOLock()
     static var publicKeyAlgorithms: [NIOSSHPublicKeyProtocol.Type] = []
-    static var signaturesLock = Lock()
+    static var signaturesLock = NIOLock()
     static var signatures: [NIOSSHSignatureProtocol.Type] = []
 }
 

--- a/Sources/NIOSSH/NIOSSHHandler.swift
+++ b/Sources/NIOSSH/NIOSSHHandler.swift
@@ -77,6 +77,9 @@ public final class NIOSSHHandler {
     }
 }
 
+@available(*, unavailable)
+extension NIOSSHHandler: Sendable {}
+
 extension NIOSSHHandler {
     enum PendingGlobalRequestResponse {
         case tcpForwarding(EventLoopPromise<GlobalRequest.TCPForwardingResponse?>)

--- a/Sources/NIOSSH/SSHPacketParser.swift
+++ b/Sources/NIOSSH/SSHPacketParser.swift
@@ -129,7 +129,7 @@ struct SSHPacketParser {
 
     internal static let maximumAllowedVersionSize = 4096
     private mutating func readVersion() throws -> String? {
-        // Looking for a string ending with \r\n
+        // Looking for a complete SSH version string, potentially with pre-lines
         let slice = self.buffer.readableBytesView
 
         // Prevent the consumed bytes for a version from exceeding the defined maximum allowed size
@@ -137,22 +137,32 @@ struct SSHPacketParser {
         // More data cannot be blindly regarded as malicious though, since this might contain multiple packets
         let maxIndex = slice.index(slice.startIndex, offsetBy: min(slice.count, Self.maximumAllowedVersionSize))
 
+        var lastLineEndIndex: ByteBufferView.Index?
+        
         for index in slice.startIndex ..< slice.endIndex {
             if index > maxIndex {
                 // Does not account for `CRLF`
                 throw NIOSSHError.excessiveVersionLength
             }
 
-            if slice[index] == 10 {
-                var version = String(decoding: slice[slice.startIndex ..< index], as: UTF8.self)
-                // read \r\n
-                self.buffer.moveReaderIndex(forwardBy: slice.startIndex.distance(to: index).advanced(by: 1))
-                if version.last == "\r" {
-                    // \r
-                    version.removeLast()
+            if slice[index] == 10 { // Found a line ending
+                let lineStartIndex = lastLineEndIndex?.advanced(by: 1) ?? slice.startIndex
+                let lineSlice = slice[lineStartIndex..<index]
+                
+                // Check if this line looks like an SSH version (any SSH version, not just 2.0)
+                if lineSlice.count >= 4 && lineSlice.starts(with: "SSH-".utf8) {
+                    // Found SSH version line, return everything up to and including this line
+                    var version = String(decoding: slice[slice.startIndex..<index], as: UTF8.self)
+                    // read including \n
+                    self.buffer.moveReaderIndex(forwardBy: slice.startIndex.distance(to: index).advanced(by: 1))
+                    // Remove the trailing \r if present (but keep \n removal logic for consistency)
+                    if version.last == "\r" {
+                        version.removeLast()
+                    }
+                    return version
                 }
                 
-                return version
+                lastLineEndIndex = index
             }
         }
 

--- a/Sources/NIOSSHPerformanceTester/BenchmarkHandshake.swift
+++ b/Sources/NIOSSHPerformanceTester/BenchmarkHandshake.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Crypto
 import NIOCore
+import NIOEmbedded
 import NIOSSH
 
 final class BenchmarkHandshake: Benchmark {

--- a/Sources/NIOSSHPerformanceTester/BenchmarkLinearThroughput.swift
+++ b/Sources/NIOSSHPerformanceTester/BenchmarkLinearThroughput.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Crypto
 import NIOCore
+import NIOEmbedded
 import NIOSSH
 
 final class BenchmarkLinearThroughput: Benchmark {

--- a/Tests/NIOSSHTests/AESGCMTests.swift
+++ b/Tests/NIOSSHTests/AESGCMTests.swift
@@ -41,7 +41,7 @@ final class AESGCMTests: XCTestCase {
     func testSimpleAES128RoundTrip() throws {
         let initialKeys = self.generateKeys(keySize: .bits128)
 
-        let aes128Encryptor = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys))
+        let aes128Encryptor = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil))
         XCTAssertNoThrow(try aes128Encryptor.encryptPacket(NIOSSHEncryptablePayload(message: .newKeys), to: &self.buffer, sequenceNumber: 0))
 
         // The newKeys message is very straightforward: a single byte. Because of that, we expect that we will need
@@ -52,7 +52,7 @@ final class AESGCMTests: XCTestCase {
         XCTAssertEqual(self.buffer.readableBytes, 36)
 
         // We should be able to decrypt this now.
-        let aes128Decryptor = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys.inverted))
+        let aes128Decryptor = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys.inverted, mac: nil))
 
         var bufferCopy = self.buffer!
         XCTAssertNoThrow(try aes128Decryptor.decryptFirstBlock(&bufferCopy))
@@ -76,7 +76,7 @@ final class AESGCMTests: XCTestCase {
     func testSimpleAES256RoundTrip() throws {
         let initialKeys = self.generateKeys(keySize: .bits256)
 
-        let aes256Encryptor = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys))
+        let aes256Encryptor = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil))
         XCTAssertNoThrow(try aes256Encryptor.encryptPacket(NIOSSHEncryptablePayload(message: .newKeys), to: &self.buffer, sequenceNumber: 0))
 
         // The newKeys message is very straightforward: a single byte. Because of that, we expect that we will need
@@ -87,7 +87,7 @@ final class AESGCMTests: XCTestCase {
         XCTAssertEqual(self.buffer.readableBytes, 36)
 
         // We should be able to decrypt this now.
-        let aes256Decryptor = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys.inverted))
+        let aes256Decryptor = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys.inverted, mac: nil))
 
         var bufferCopy = self.buffer!
         XCTAssertNoThrow(try aes256Decryptor.decryptFirstBlock(&bufferCopy))
@@ -114,13 +114,13 @@ final class AESGCMTests: XCTestCase {
         // We want to check that each key is rejected separately.
         var initialKeys = initial128BitKeys
         initialKeys.inboundEncryptionKey = SymmetricKey(size: .bits256)
-        XCTAssertThrowsError(try AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys)) { error in
+        XCTAssertThrowsError(try AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidKeySize)
         }
 
         initialKeys = initial128BitKeys
         initialKeys.outboundEncryptionKey = SymmetricKey(size: .bits256)
-        XCTAssertThrowsError(try AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys)) { error in
+        XCTAssertThrowsError(try AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidKeySize)
         }
 
@@ -129,13 +129,13 @@ final class AESGCMTests: XCTestCase {
         // We want to check that each key is rejected separately.
         initialKeys = initial256BitKeys
         initialKeys.inboundEncryptionKey = SymmetricKey(size: .bits128)
-        XCTAssertThrowsError(try AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys)) { error in
+        XCTAssertThrowsError(try AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidKeySize)
         }
 
         initialKeys = initial256BitKeys
         initialKeys.outboundEncryptionKey = SymmetricKey(size: .bits128)
-        XCTAssertThrowsError(try AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys)) { error in
+        XCTAssertThrowsError(try AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidKeySize)
         }
     }
@@ -144,8 +144,8 @@ final class AESGCMTests: XCTestCase {
         let initial128BitKeys = self.generateKeys(keySize: .bits128)
         let initial256BitKeys = self.generateKeys(keySize: .bits256)
 
-        let aes128 = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: initial128BitKeys))
-        let aes256 = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: initial256BitKeys))
+        let aes128 = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: initial128BitKeys, mac: nil))
+        let aes256 = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: initial256BitKeys, mac: nil))
 
         // We want to check that each key is rejected separately.
         var updatedKeys = initial128BitKeys
@@ -181,50 +181,50 @@ final class AESGCMTests: XCTestCase {
         // We want to check that each nonce is rejected separately.
         var initialKeys = initial128BitKeys
         initialKeys.initialInboundIV = Array(randomBytes: 11)
-        XCTAssertThrowsError(try AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys)) { error in
+        XCTAssertThrowsError(try AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidNonceLength)
         }
 
         initialKeys = initial128BitKeys
         initialKeys.initialOutboundIV = Array(randomBytes: 11)
-        XCTAssertThrowsError(try AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys)) { error in
+        XCTAssertThrowsError(try AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidNonceLength)
         }
 
         initialKeys = initial128BitKeys
         initialKeys.initialInboundIV = Array(randomBytes: 13)
-        XCTAssertThrowsError(try AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys)) { error in
+        XCTAssertThrowsError(try AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidNonceLength)
         }
 
         initialKeys = initial128BitKeys
         initialKeys.initialOutboundIV = Array(randomBytes: 13)
-        XCTAssertThrowsError(try AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys)) { error in
+        XCTAssertThrowsError(try AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidNonceLength)
         }
 
         // We want to check that each key is rejected separately.
         initialKeys = initial256BitKeys
         initialKeys.initialInboundIV = Array(randomBytes: 11)
-        XCTAssertThrowsError(try AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys)) { error in
+        XCTAssertThrowsError(try AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidNonceLength)
         }
 
         initialKeys = initial256BitKeys
         initialKeys.initialOutboundIV = Array(randomBytes: 11)
-        XCTAssertThrowsError(try AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys)) { error in
+        XCTAssertThrowsError(try AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidNonceLength)
         }
 
         initialKeys = initial256BitKeys
         initialKeys.initialInboundIV = Array(randomBytes: 13)
-        XCTAssertThrowsError(try AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys)) { error in
+        XCTAssertThrowsError(try AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidNonceLength)
         }
 
         initialKeys = initial256BitKeys
         initialKeys.initialOutboundIV = Array(randomBytes: 13)
-        XCTAssertThrowsError(try AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys)) { error in
+        XCTAssertThrowsError(try AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys, mac: nil)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidNonceLength)
         }
     }
@@ -233,8 +233,8 @@ final class AESGCMTests: XCTestCase {
         let initial128BitKeys = self.generateKeys(keySize: .bits128)
         let initial256BitKeys = self.generateKeys(keySize: .bits256)
 
-        let aes128 = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: initial128BitKeys))
-        let aes256 = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: initial256BitKeys))
+        let aes128 = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: initial128BitKeys, mac: nil))
+        let aes256 = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: initial256BitKeys, mac: nil))
 
         // We want to check that each nonce is rejected separately.
         var updatedKeys = initial128BitKeys
@@ -293,7 +293,7 @@ final class AESGCMTests: XCTestCase {
         // up to the next multiple of the block size (52 bytes).
         let invalidSizes = Array(0 ..< 36) + Array(37 ..< 52)
 
-        let aes128 = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: self.generateKeys(keySize: .bits128)))
+        let aes128 = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: self.generateKeys(keySize: .bits128), mac: nil))
         var buffer = ByteBufferAllocator().buffer(capacity: 52)
 
         for ciphertextSize in invalidSizes {
@@ -313,7 +313,7 @@ final class AESGCMTests: XCTestCase {
         // up to the next multiple of the block size (52 bytes).
         let invalidSizes = Array(0 ..< 36) + Array(37 ..< 52)
 
-        let aes256 = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: self.generateKeys(keySize: .bits256)))
+        let aes256 = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: self.generateKeys(keySize: .bits256), mac: nil))
         var buffer = ByteBufferAllocator().buffer(capacity: 52)
 
         for ciphertextSize in invalidSizes {
@@ -349,7 +349,7 @@ final class AESGCMTests: XCTestCase {
         XCTAssertEqual(buffer.readableBytes, 36)
 
         // We can now attempt to decrypt this packet.
-        let aes128 = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: keys))
+        let aes128 = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: keys, mac: nil))
         XCTAssertThrowsError(try aes128.decryptAndVerifyRemainingPacket(&buffer, sequenceNumber: 0)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .excessPadding)
         }
@@ -378,7 +378,7 @@ final class AESGCMTests: XCTestCase {
         XCTAssertEqual(buffer.readableBytes, 36)
 
         // We can now attempt to decrypt this packet.
-        let aes256 = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: keys))
+        let aes256 = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: keys, mac: nil))
         XCTAssertThrowsError(try aes256.decryptAndVerifyRemainingPacket(&buffer, sequenceNumber: 0)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .excessPadding)
         }
@@ -407,7 +407,7 @@ final class AESGCMTests: XCTestCase {
         XCTAssertEqual(buffer.readableBytes, 36)
 
         // We can now attempt to decrypt this packet.
-        let aes128 = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: keys))
+        let aes128 = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: keys, mac: nil))
         XCTAssertThrowsError(try aes128.decryptAndVerifyRemainingPacket(&buffer, sequenceNumber: 0)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .insufficientPadding)
         }
@@ -436,7 +436,7 @@ final class AESGCMTests: XCTestCase {
         XCTAssertEqual(buffer.readableBytes, 36)
 
         // We can now attempt to decrypt this packet.
-        let aes256 = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: keys))
+        let aes256 = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: keys, mac: nil))
         XCTAssertThrowsError(try aes256.decryptAndVerifyRemainingPacket(&buffer, sequenceNumber: 0)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .insufficientPadding)
         }

--- a/Tests/NIOSSHTests/ECKeyExchangeTests.swift
+++ b/Tests/NIOSSHTests/ECKeyExchangeTests.swift
@@ -68,7 +68,7 @@ final class KeyExchangeTests: XCTestCase {
                                                      serverHostKey: serverHostKey,
                                                      initialExchangeBytes: &initialExchangeBytes,
                                                      allocator: ByteBufferAllocator(),
-                                                     expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                     expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         initialExchangeBytes.clear()
@@ -77,7 +77,7 @@ final class KeyExchangeTests: XCTestCase {
             try client.receiveServerKeyExchangePayload(serverKeyExchangeMessage: serverResponse,
                                                        initialExchangeBytes: &initialExchangeBytes,
                                                        allocator: ByteBufferAllocator(),
-                                                       expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                       expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         // Check we agree on the session ID and the keys.
@@ -116,7 +116,7 @@ final class KeyExchangeTests: XCTestCase {
                                                      serverHostKey: serverHostKey,
                                                      initialExchangeBytes: &initialExchangeBytes,
                                                      allocator: ByteBufferAllocator(),
-                                                     expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                     expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         initialExchangeBytes.clear()
@@ -125,7 +125,7 @@ final class KeyExchangeTests: XCTestCase {
             try client.receiveServerKeyExchangePayload(serverKeyExchangeMessage: serverResponse,
                                                        initialExchangeBytes: &initialExchangeBytes,
                                                        allocator: ByteBufferAllocator(),
-                                                       expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                       expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         // Check we agree on the session ID and the keys.
@@ -145,7 +145,7 @@ final class KeyExchangeTests: XCTestCase {
                                                      serverHostKey: serverHostKey,
                                                      initialExchangeBytes: &initialExchangeBytes,
                                                      allocator: ByteBufferAllocator(),
-                                                     expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                     expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         initialExchangeBytes.clear()
@@ -154,7 +154,7 @@ final class KeyExchangeTests: XCTestCase {
             try client.receiveServerKeyExchangePayload(serverKeyExchangeMessage: serverResponse,
                                                        initialExchangeBytes: &initialExchangeBytes,
                                                        allocator: ByteBufferAllocator(),
-                                                       expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                       expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         // Check we agree on the session ID and the keys.
@@ -174,7 +174,7 @@ final class KeyExchangeTests: XCTestCase {
                                                      serverHostKey: serverHostKey,
                                                      initialExchangeBytes: &initialExchangeBytes,
                                                      allocator: ByteBufferAllocator(),
-                                                     expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                     expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         initialExchangeBytes.clear()
@@ -183,7 +183,7 @@ final class KeyExchangeTests: XCTestCase {
             try client.receiveServerKeyExchangePayload(serverKeyExchangeMessage: serverResponse,
                                                        initialExchangeBytes: &initialExchangeBytes,
                                                        allocator: ByteBufferAllocator(),
-                                                       expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                       expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         // Check we agree on the session ID and the keys.
@@ -203,7 +203,7 @@ final class KeyExchangeTests: XCTestCase {
                                                      serverHostKey: serverHostKey,
                                                      initialExchangeBytes: &initialExchangeBytes,
                                                      allocator: ByteBufferAllocator(),
-                                                     expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                     expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         initialExchangeBytes.clear()
@@ -212,7 +212,7 @@ final class KeyExchangeTests: XCTestCase {
             try client.receiveServerKeyExchangePayload(serverKeyExchangeMessage: serverResponse,
                                                        initialExchangeBytes: &initialExchangeBytes,
                                                        allocator: ByteBufferAllocator(),
-                                                       expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                       expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         // Check we agree on the session ID and the keys.
@@ -232,7 +232,7 @@ final class KeyExchangeTests: XCTestCase {
                                                      serverHostKey: serverHostKey,
                                                      initialExchangeBytes: &initialExchangeBytes,
                                                      allocator: ByteBufferAllocator(),
-                                                     expectedKeySizes: AES256GCMOpenSSHTransportProtection.keySizes)
+                                                     expectedKeySizes: try AES256GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         initialExchangeBytes.clear()
@@ -241,7 +241,7 @@ final class KeyExchangeTests: XCTestCase {
             try client.receiveServerKeyExchangePayload(serverKeyExchangeMessage: serverResponse,
                                                        initialExchangeBytes: &initialExchangeBytes,
                                                        allocator: ByteBufferAllocator(),
-                                                       expectedKeySizes: AES256GCMOpenSSHTransportProtection.keySizes)
+                                                       expectedKeySizes: try AES256GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         // Check we agree on the session ID and the keys.
@@ -265,14 +265,14 @@ final class KeyExchangeTests: XCTestCase {
                                                      serverHostKey: serverHostKey,
                                                      initialExchangeBytes: &serverInitialBytes,
                                                      allocator: ByteBufferAllocator(),
-                                                     expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                     expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         XCTAssertThrowsError(
             try client.receiveServerKeyExchangePayload(serverKeyExchangeMessage: serverResponse,
                                                        initialExchangeBytes: &clientInitialBytes,
                                                        allocator: ByteBufferAllocator(),
-                                                       expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                       expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         ) { error in
             XCTAssertEqual((error as? NIOSSHError).map { $0.type }, .invalidExchangeHashSignature)
         }
@@ -292,7 +292,7 @@ final class KeyExchangeTests: XCTestCase {
                                                      serverHostKey: serverHostKey,
                                                      initialExchangeBytes: &initialExchangeBytes,
                                                      allocator: ByteBufferAllocator(),
-                                                     expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                     expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         )
 
         initialExchangeBytes.clear()
@@ -309,7 +309,7 @@ final class KeyExchangeTests: XCTestCase {
             try client.receiveServerKeyExchangePayload(serverKeyExchangeMessage: serverResponse,
                                                        initialExchangeBytes: &initialExchangeBytes,
                                                        allocator: ByteBufferAllocator(),
-                                                       expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+                                                       expectedKeySizes: try AES128GCMOpenSSHTransportProtection.keySizes(forMac: nil))
         ) { error in
             XCTAssertEqual((error as? NIOSSHError).map { $0.type }, .invalidExchangeHashSignature)
         }

--- a/Tests/NIOSSHTests/EndToEndTests.swift
+++ b/Tests/NIOSSHTests/EndToEndTests.swift
@@ -15,6 +15,7 @@
 import Crypto
 import NIOCore
 import NIOEmbedded
+import NIOFoundationCompat
 @testable import NIOSSH
 import XCTest
 
@@ -29,11 +30,11 @@ final class CustomTransportProtection: NIOSSHTransportProtection {
     static let macNames = ["insecure-sha1"]
     static var wasUsed = false
     
-    static var keySizes: ExpectedKeySizes {
+    static func keySizes(forMac mac: String?) throws -> ExpectedKeySizes {
         .init(ivSize: 19, encryptionKeySize: 17, macKeySize: 15)
     }
     
-    required init(initialKeys: NIOSSHSessionKeys) throws {}
+    required init(initialKeys: NIOSSHSessionKeys, mac: String?) throws {}
     
     static var cipherBlockSize: Int { 18 }
     var macBytes: Int { 20 }

--- a/Tests/NIOSSHTests/HostKeyTests.swift
+++ b/Tests/NIOSSHTests/HostKeyTests.swift
@@ -14,6 +14,7 @@
 
 import Crypto
 import NIOCore
+import NIOFoundationCompat
 @testable import NIOSSH
 import XCTest
 

--- a/Tests/NIOSSHTests/SSHEncryptedTrafficTests.swift
+++ b/Tests/NIOSSHTests/SSHEncryptedTrafficTests.swift
@@ -140,7 +140,7 @@ final class SSHEncryptedTrafficTests: XCTestCase {
                                      inboundEncryptionKey: .init(data: [241, 99, 181, 233, 148, 184, 187, 134, 80, 195, 18, 18, 218, 44, 118, 219, 120, 69, 225, 63, 105, 179, 131, 204, 156, 172, 105, 142, 12, 75, 148, 88]),
                                      outboundEncryptionKey: .init(data: [109, 86, 219, 88, 84, 20, 197, 13, 74, 19, 120, 17, 95, 59, 25, 181, 12, 237, 109, 51, 239, 86, 169, 53, 85, 35, 162, 88, 215, 199, 219, 82]),
                                      inboundMACKey: .init(size: .bits128), outboundMACKey: .init(size: .bits128))
-        let protection = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: keys))
+        let protection = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: keys, mac: nil))
 
         self.parser.addEncryption(protection)
 
@@ -173,15 +173,15 @@ private extension SSHEncryptedTrafficTests {
 
         private func aes128Protection() -> (client: AES128GCMOpenSSHTransportProtection, server: AES128GCMOpenSSHTransportProtection) {
             let keys = self.generateKeys(keySize: .bits128, ivSize: 12, macSize: .bits128)
-            let client = try! AES128GCMOpenSSHTransportProtection(initialKeys: keys)
-            let server = try! AES128GCMOpenSSHTransportProtection(initialKeys: keys.inverted)
+            let client = try! AES128GCMOpenSSHTransportProtection(initialKeys: keys, mac: nil)
+            let server = try! AES128GCMOpenSSHTransportProtection(initialKeys: keys.inverted, mac: nil)
             return (client: client, server: server)
         }
 
         private func aes256Protection() -> (client: AES256GCMOpenSSHTransportProtection, server: AES256GCMOpenSSHTransportProtection) {
             let keys = self.generateKeys(keySize: .bits256, ivSize: 12, macSize: .bits128)
-            let client = try! AES256GCMOpenSSHTransportProtection(initialKeys: keys)
-            let server = try! AES256GCMOpenSSHTransportProtection(initialKeys: keys.inverted)
+            let client = try! AES256GCMOpenSSHTransportProtection(initialKeys: keys, mac: nil)
+            let server = try! AES256GCMOpenSSHTransportProtection(initialKeys: keys.inverted, mac: nil)
             return (client: client, server: server)
         }
 

--- a/Tests/NIOSSHTests/Utilities.swift
+++ b/Tests/NIOSSHTests/Utilities.swift
@@ -130,7 +130,7 @@ class TestTransportProtection: NIOSSHTransportProtection {
         []
     }
 
-    static var keySizes: ExpectedKeySizes {
+    static func keySizes(forMac mac: String?) throws -> ExpectedKeySizes {
         .init(ivSize: 12, encryptionKeySize: 16, macKeySize: 16)
     }
 
@@ -141,9 +141,10 @@ class TestTransportProtection: NIOSSHTransportProtection {
 
     private var lastFirstBlock: ByteBufferView?
 
-    required init(initialKeys: NIOSSHSessionKeys) {
-        precondition(initialKeys.outboundEncryptionKey.bitCount == Self.keySizes.encryptionKeySize * 8)
-        precondition(initialKeys.inboundEncryptionKey.bitCount == Self.keySizes.encryptionKeySize * 8)
+    required init(initialKeys: NIOSSHSessionKeys, mac: String?) throws {
+        let keySizes = try Self.keySizes(forMac: mac)
+        precondition(initialKeys.outboundEncryptionKey.bitCount == keySizes.encryptionKeySize * 8)
+        precondition(initialKeys.inboundEncryptionKey.bitCount == keySizes.encryptionKeySize * 8)
         self.outboundEncryptionKey = initialKeys.outboundEncryptionKey.withUnsafeBytes {
             ByteBuffer(bytes: $0)
         }
@@ -155,8 +156,9 @@ class TestTransportProtection: NIOSSHTransportProtection {
     }
 
     func updateKeys(_ newKeys: NIOSSHSessionKeys) throws {
-        precondition(newKeys.outboundEncryptionKey.bitCount == Self.keySizes.encryptionKeySize * 8)
-        precondition(newKeys.inboundEncryptionKey.bitCount == Self.keySizes.encryptionKeySize * 8)
+        let keySizes = try Self.keySizes(forMac: nil)
+        precondition(newKeys.outboundEncryptionKey.bitCount == keySizes.encryptionKeySize * 8)
+        precondition(newKeys.inboundEncryptionKey.bitCount == keySizes.encryptionKeySize * 8)
         self.outboundEncryptionKey = newKeys.outboundEncryptionKey.withUnsafeBytes {
             ByteBuffer(bytes: $0)
         }

--- a/Tests/NIOSSHTests/UtilitiesTests.swift
+++ b/Tests/NIOSSHTests/UtilitiesTests.swift
@@ -33,22 +33,22 @@ final class UtilitiesTests: XCTestCase {
         let outboundEncryptionKey = SymmetricKey(size: .bits128)
         let inboundMACKey = SymmetricKey(size: .bits128)
         let outboundMACKey = SymmetricKey(size: .bits128)
-        let client = TestTransportProtection(initialKeys: .init(
+        let client = try TestTransportProtection(initialKeys: .init(
             initialInboundIV: [],
             initialOutboundIV: [],
             inboundEncryptionKey: inboundEncryptionKey,
             outboundEncryptionKey: outboundEncryptionKey,
             inboundMACKey: inboundMACKey,
             outboundMACKey: outboundMACKey
-        ))
-        let server = TestTransportProtection(initialKeys: .init(
+        ), mac: nil)
+        let server = try TestTransportProtection(initialKeys: .init(
             initialInboundIV: [],
             initialOutboundIV: [],
             inboundEncryptionKey: outboundEncryptionKey,
             outboundEncryptionKey: inboundEncryptionKey,
             inboundMACKey: outboundMACKey,
             outboundMACKey: inboundMACKey
-        ))
+        ), mac: nil)
         let message = SSHMessage.channelRequest(.init(recipientChannel: 1, type: .exec("uname"), wantReply: false))
         let allocator = ByteBufferAllocator()
         var buffer = allocator.buffer(capacity: 1024)


### PR DESCRIPTION
This pull request introduces several updates to enhance concurrency support, modernize dependencies, improve thread safety, and refine test cases in the SwiftNIO SSH package. The most significant changes include upgrading the Swift tools version, adding strict concurrency settings, replacing `Lock` with `NIOLock` for thread safety, and modifying AES encryption tests to include a new `mac` parameter.

### Updates to concurrency and dependency management:

* **Swift tools version upgrade**: Updated the `swift-tools-version` in `Package.swift` from 5.6 to 5.10 to utilize the latest Swift features.
* **Strict concurrency settings**: Introduced new concurrency-related Swift settings, such as enabling `StrictConcurrency` and `InferSendableFromCaptures`, with an optional development mode for stricter enforcement. [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR18-R35) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL44-R63) [[3]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL81-R119)
* **Dependency updates**: Upgraded the `swift-nio` dependency to version 2.81.0 and extended the version range for `swift-crypto` to include up to 4.0.0.

### Thread safety improvements:

* **Replaced `Lock` with `NIOLock`**: Enhanced thread safety by replacing the use of `Lock` with `NIOLock` in various internal structures, ensuring compatibility with NIO's locking mechanisms.

### Test refinements:

* **AES encryption tests**: Updated test cases for `AES128GCMOpenSSHTransportProtection` and `AES256GCMOpenSSHTransportProtection` to include a new `mac` parameter, ensuring compatibility with recent changes and improving test coverage. [[1]](diffhunk://#diff-b4f64732addb6e7790293edc2a10b6eb4b67452161ef9d959407d4aa24f2bf19L44-R44) [[2]](diffhunk://#diff-b4f64732addb6e7790293edc2a10b6eb4b67452161ef9d959407d4aa24f2bf19L55-R55) [[3]](diffhunk://#diff-b4f64732addb6e7790293edc2a10b6eb4b67452161ef9d959407d4aa24f2bf19L79-R79) [[4]](diffhunk://#diff-b4f64732addb6e7790293edc2a10b6eb4b67452161ef9d959407d4aa24f2bf19L117-R123) [[5]](diffhunk://#diff-b4f64732addb6e7790293edc2a10b6eb4b67452161ef9d959407d4aa24f2bf19L236-R237)

### Miscellaneous improvements:

* **Additional imports**: Added necessary imports, such as `Foundation` and `NIOEmbedded`, to improve compatibility and functionality across multiple files. [[1]](diffhunk://#diff-5f500782a886e937ce4b32929b46ba986f56944b69f580cbd55d82b75de0fd8bR16) [[2]](diffhunk://#diff-d7ef5ab9c1b212606289d9dab02974572b40570fc140b8acdad26f1997134c60R16) [[3]](diffhunk://#diff-b6c19264326dad39f64d758e254819e9a531c352a5235d4e3e14b2ef102dcf4cR16)
* **Sendable conformance**: Marked `NIOSSHHandler` as unavailable for `Sendable` conformance to align with concurrency updates.