### PR TITLE
Import CDispatch when required

### DIFF
--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -15,6 +15,11 @@
 import Crypto
 import Dispatch
 import Foundation
+
+#if canImport(CDispatch)
+import CDispatch
+#endif
+
 import NIOCore
 #if canImport(Darwin)
 import Darwin


### PR DESCRIPTION
Fix orlandos-nl/Citadel#114 issue.

Testable on [a temporary Citadel fork](https://github.com/florentmorin/Citadel.git).

Tested just today on Bookworm (ARM64, Linux, RPi) and macOS 26.