### PR TITLE
Fix: Add NIO product dependency for Mac Catalyst builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,6 +54,7 @@ let package = Package(
         .target(
             name: "NIOSSH",
             dependencies: [
+                .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),


### PR DESCRIPTION
## Summary
- Added `.product(name: "NIO", package: "swift-nio")` to the NIOSSH target dependencies
- The NIOSSH target uses `import NIO` in `CustomKeys.swift` but only declared `NIOCore` as a dependency
- This causes `unable to resolve module dependency: 'NIO'` when building for Mac Catalyst (`platform=macOS,variant=Mac Catalyst`)

## Problem
Building any project that depends on NIOSSH for Mac Catalyst fails with:
```
CustomKeys.swift:16:8: error: unable to resolve module dependency: 'NIO'
```

The `NIO` umbrella module re-exports `NIOCore`, `NIOEmbedded`, and `NIOPosix`. On iOS simulator/device, SPM resolves it transitively. On Mac Catalyst, the stricter module resolution requires it to be an explicit dependency.

## Fix
One-line addition of the `NIO` product to the NIOSSH target's dependency list in `Package.swift`.

## Test plan
- [x] Build succeeds for iOS simulator
- [x] Build succeeds for Mac Catalyst (`platform=macOS,variant=Mac Catalyst`)