### PR TITLE
Support RSA certificate authentication via custom keys

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -97,6 +97,7 @@ let package = Package(
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
             ],
             swiftSettings: strictConcurrencySettings
         ),

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -77,6 +77,7 @@ let package = Package(
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
             ]
         ),
     ]

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -77,6 +77,7 @@ let package = Package(
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
             ]
         ),
     ]

--- a/Sources/NIOSSH/Keys And Signatures/CustomKeys.swift
+++ b/Sources/NIOSSH/Keys And Signatures/CustomKeys.swift
@@ -29,11 +29,14 @@ public protocol NIOSSHSignatureProtocol {
     /// The raw reprentation of this signature as a blob.
     var rawRepresentation: Data { get }
 
-    /// Serializes and writes the signature to the buffer. The calling function SHOULD NOT keep track of the size of the written blob.
-    /// If the result is not a fixed size, the serialized format SHOULD include a length.
+    /// Serializes and writes only the algorithm-specific signature body to the buffer.
+    ///
+    /// NIOSSH writes `signaturePrefix` before calling this method. Implementations MUST NOT write
+    /// that identifier again. If the body is not a fixed size, its serialized format SHOULD include
+    /// a length.
     func write(to buffer: inout ByteBuffer) -> Int
 
-    /// Reads this Signature from the buffer using the same format implemented in `write(to:)`
+    /// Reads the algorithm-specific body after NIOSSH has consumed `signaturePrefix`.
     static func read(from buffer: inout ByteBuffer) throws -> Self
 }
 
@@ -55,11 +58,12 @@ public protocol NIOSSHPublicKeyProtocol {
     /// Verifies that `signature` is the result of signing `data` using the private key that this public key is derived from.
     func isValidSignature<D: DataProtocol>(_ signature: NIOSSHSignatureProtocol, for data: D) -> Bool
 
-    /// Serializes and writes the public key to the buffer. The calling function SHOULD NOT keep track of the size of the written blob.
-    /// If the result is not a fixed size, the serialized format SHOULD include a length.
+    /// Serializes and writes only the algorithm-specific public-key body to the buffer.
+    /// NIOSSH writes the applicable public-key or certificate identifier before calling this method.
+    /// If the body is not a fixed size, its serialized format SHOULD include a length.
     func write(to buffer: inout ByteBuffer) -> Int
 
-    /// Reads this Public Key from the buffer using the same format implemented in `write(to:)`
+    /// Reads the algorithm-specific body after NIOSSH has consumed its identifier.
     static func read(from buffer: inout ByteBuffer) throws -> Self
 }
 
@@ -75,15 +79,42 @@ public protocol NIOSSHPrivateKeyProtocol {
     /// The returned value MUST NOT overlap with other private key implementations or a specifications that the private key does not implement.
     static var keyPrefix: String { get }
 
+    /// The identifier used to select this key's public-key user-authentication algorithm mapping.
+    ///
+    /// This value is selected before the authentication payload is signed. It is deliberately
+    /// separate from the public-key format and is used to resolve the algorithm name carried in
+    /// `SSH_MSG_USERAUTH_REQUEST`. It must match the name or an alias of a registered
+    /// `NIOSSHUserAuthenticationAlgorithm`; signature identifiers do not select authentication
+    /// mappings. The default preserves the legacy behavior of using `publicKey.publicKeyPrefix`;
+    /// implementations that need a different authentication name must override it.
+    var userAuthenticationAlgorithmIdentifier: String { get }
+
     /// A public key instance that is able to verify signatures that are created using this private key.
     var publicKey: NIOSSHPublicKeyProtocol { get }
 
     /// Creates a signature, proving that `data` has been sent by the holder of this private key, and can be verified by `publicKey`.
     func signature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol
+
+    /// Creates the signature used for public-key user authentication.
+    ///
+    /// The default implementation delegates to `signature(for:)`. Custom keys that use a
+    /// different signature algorithm for user authentication than for host-key signing can
+    /// override this method without wrapping the key or rewriting the authentication payload.
+    func userAuthenticationSignature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol
 }
 
 internal extension NIOSSHPrivateKeyProtocol {
     var keyPrefix: String {
         Self.keyPrefix
+    }
+}
+
+public extension NIOSSHPrivateKeyProtocol {
+    var userAuthenticationAlgorithmIdentifier: String {
+        self.publicKey.publicKeyPrefix
+    }
+
+    func userAuthenticationSignature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol {
+        try self.signature(for: data)
     }
 }

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -13,18 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
-import Dispatch
 import Foundation
 import NIOCore
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#elseif canImport(Musl)
-import Musl
-#elseif canImport(Bionic)
-import Bionic
-#endif
 
 /// A `NIOSSHCertifiedPublicKey` is an SSH public key combined with an SSH certificate.
 ///
@@ -295,12 +285,12 @@ extension NIOSSHCertifiedPublicKey {
             throw NIOSSHError.invalidCertificate(diagnostics: "Certificate is not valid for this principal")
         }
 
-        // This can only be negative if we're in a terribly misconfigured system, so we can safely just turn this directly
-        // into a UInt64.
-        let now = DispatchWallTime.now()
-        let validAfter = DispatchWallTime(secondsSinceEpoch: self.validAfter)
-        let validBefore = DispatchWallTime(secondsSinceEpoch: self.validBefore)
-        guard validAfter <= now, validBefore > now else {
+        let secondsSinceEpoch = Date().timeIntervalSince1970
+        guard secondsSinceEpoch >= 0, secondsSinceEpoch < TimeInterval(UInt64.max) else {
+            throw NIOSSHError.invalidCertificate(diagnostics: "System clock is outside the supported range")
+        }
+        let now = UInt64(secondsSinceEpoch)
+        guard self.validAfter <= now, self.validBefore > now else {
             throw NIOSSHError.invalidCertificate(diagnostics: "Certificate is no longer valid")
         }
 
@@ -340,7 +330,10 @@ extension NIOSSHCertifiedPublicKey {
         case .certified:
             preconditionFailure("base key cannot be certified")
         case .custom(let custom):
-            return custom.publicKeyPrefix.utf8
+            guard let prefix = NIOSSHPublicKey.certificatePublicKeyPrefix(for: custom) else {
+                preconditionFailure("custom public key was not registered with a certificate format")
+            }
+            return prefix.utf8
         }
     }
 
@@ -366,7 +359,11 @@ extension NIOSSHCertifiedPublicKey {
         } else if prefix.elementsEqual(Self.p521KeyPrefix) {
             return NIOSSHPublicKey.ecdsaP521PublicKeyPrefix
         } else {
-            throw NIOSSHError.unknownPublicKey(algorithm: String(decoding: prefix, as: UTF8.self))
+            let prefixString = String(decoding: prefix, as: UTF8.self)
+            if let basePrefix = NIOSSHPublicKey.basePublicKeyPrefix(forCertificatePublicKeyPrefix: prefixString) {
+                return basePrefix.utf8
+            }
+            throw NIOSSHError.unknownPublicKey(algorithm: prefixString)
         }
     }
 }
@@ -460,6 +457,12 @@ extension NIOSSHCertifiedPublicKey {
                 if case .certified = newValue.backingKey {
                     preconditionFailure("Certificate may not use certified key as public key")
                 }
+                if case .custom(let customKey) = newValue.backingKey {
+                    precondition(
+                        NIOSSHPublicKey.certificatePublicKeyPrefix(for: customKey) != nil,
+                        "Custom public key must be registered with a certificate format"
+                    )
+                }
             }
         }
 
@@ -498,6 +501,13 @@ extension NIOSSHCertifiedPublicKey {
             }
             if case .certified = signatureKey.backingKey {
                 throw NIOSSHError.invalidCertificate(diagnostics: "Certificate may not be signed by certified key")
+            }
+            if case .custom(let customKey) = key.backingKey,
+                NIOSSHPublicKey.certificatePublicKeyPrefix(for: customKey) == nil
+            {
+                throw NIOSSHError.invalidCertificate(
+                    diagnostics: "Custom public key was not registered with a certificate format"
+                )
             }
 
             self.nonce = nonce
@@ -729,12 +739,5 @@ extension ByteBuffer {
         }
 
         return map
-    }
-}
-
-extension DispatchWallTime {
-    init(secondsSinceEpoch: UInt64) {
-        let t = timespec(tv_sec: time_t(secondsSinceEpoch), tv_nsec: 0)
-        self = DispatchWallTime(timespec: t)
     }
 }

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
@@ -76,6 +76,26 @@ public struct NIOSSHPrivateKey {
         #endif
         }
     }
+
+    /// The identifier used to select the user-authentication algorithm mapping.
+    internal var userAuthenticationAlgorithmIdentifier: String {
+        switch self.backingKey {
+        case .ed25519:
+            return "ssh-ed25519"
+        case .ecdsaP256:
+            return "ecdsa-sha2-nistp256"
+        case .ecdsaP384:
+            return "ecdsa-sha2-nistp384"
+        case .ecdsaP521:
+            return "ecdsa-sha2-nistp521"
+        case .custom(let key):
+            return key.userAuthenticationAlgorithmIdentifier
+        #if canImport(Darwin)
+        case .secureEnclaveP256:
+            return "ecdsa-sha2-nistp256"
+        #endif
+        }
+    }
 }
 
 extension NIOSSHPrivateKey {
@@ -147,7 +167,7 @@ extension NIOSSHPrivateKey {
             let signature = try key.signature(for: payload.bytes.readableBytesView)
             return NIOSSHSignature(backingSignature: .ecdsaP521(signature))
         case .custom(let key):
-            let signature = try key.signature(for: payload.bytes.readableBytesView)
+            let signature = try key.userAuthenticationSignature(for: payload.bytes.readableBytesView)
             return NIOSSHSignature(backingSignature: .custom(signature))
         #if canImport(Darwin)
         case .secureEnclaveP256(let key):

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKey.swift
@@ -199,28 +199,302 @@ extension NIOSSHPublicKey {
         }
     }
 
-    private static let bundledAlgorithms: [String.UTF8View] = [
-        Self.ed25519PublicKeyPrefix, Self.ecdsaP384PublicKeyPrefix, Self.ecdsaP256PublicKeyPrefix, Self.ecdsaP521PublicKeyPrefix,
-    ]
-
-    static var knownAlgorithms: [String.UTF8View] {
-        bundledAlgorithms + customPublicKeyAlgorithms.map { $0.publicKeyPrefix.utf8 }
-    }
-
     static var customPublicKeyAlgorithms: [NIOSSHPublicKeyProtocol.Type] {
-        _CustomAlgorithms.publicKeyAlgorithmsLock.withLock {
-            _CustomAlgorithms.publicKeyAlgorithms
+        var identifiers = Set<ObjectIdentifier>()
+        return customPublicKeyAlgorithmRegistrations.compactMap { registration in
+            let identifier = ObjectIdentifier(registration.publicKey)
+            return identifiers.insert(identifier).inserted ? registration.publicKey : nil
         }
     }
 
     static var customSignatures: [NIOSSHSignatureProtocol.Type] {
-        _CustomAlgorithms.signaturesLock.withLock {
-            _CustomAlgorithms.signatures
+        var identifiers = Set<ObjectIdentifier>()
+        return customPublicKeyAlgorithmRegistrations.compactMap { registration in
+            let identifier = ObjectIdentifier(registration.signature)
+            return identifiers.insert(identifier).inserted ? registration.signature : nil
+        }
+    }
+
+    static var customPublicKeyAlgorithmRegistrations: [PublicKeyAlgorithmRegistration] {
+        _CustomAlgorithms.publicKeyAlgorithmRegistrationsLock.withLock {
+            _CustomAlgorithms.publicKeyAlgorithmRegistrations
+        }
+    }
+}
+
+/// Describes the algorithm identifiers used by a custom public key during SSH user authentication.
+///
+/// SSH uses three independently-framed identifiers in public-key authentication: the public-key
+/// format inside the key blob, the algorithm in `SSH_MSG_USERAUTH_REQUEST`, and the algorithm inside
+/// the signature blob. The public-key and signature formats come from `NIOSSHPublicKeyProtocol` and
+/// `NIOSSHSignatureProtocol`; this value supplies the user-authentication name and, when supported,
+/// the certificate-specific names.
+public struct NIOSSHUserAuthenticationAlgorithm: Hashable, Sendable {
+    /// The certificate form of a user-authentication algorithm.
+    public struct Certificate: Hashable, Sendable {
+        /// The canonical identifier written inside a certificate public-key blob.
+        public var publicKeyPrefix: String
+
+        /// The algorithm identifier carried in certificate authentication requests.
+        public var name: String
+
+        /// Equivalent authentication identifiers accepted while parsing.
+        public var aliases: [String]
+
+        public init(
+            publicKeyPrefix: String,
+            name: String,
+            aliases: [String] = []
+        ) {
+            self.publicKeyPrefix = publicKeyPrefix
+            self.name = name
+            self.aliases = aliases
+        }
+    }
+
+    /// The algorithm identifier carried in a non-certificate authentication request.
+    public var name: String
+
+    /// Equivalent authentication identifiers accepted while parsing.
+    public var aliases: [String]
+
+    /// Certificate-specific identifiers, or `nil` when this registration cannot encode certificates.
+    public var certificate: Certificate?
+
+    public init(
+        name: String,
+        aliases: [String] = [],
+        certificate: Certificate? = nil
+    ) {
+        self.name = name
+        self.aliases = aliases
+        self.certificate = certificate
+    }
+}
+
+struct PublicKeyAlgorithmRegistration {
+    var publicKey: NIOSSHPublicKeyProtocol.Type
+    var signature: NIOSSHSignatureProtocol.Type
+    var userAuthenticationAlgorithm: NIOSSHUserAuthenticationAlgorithm
+}
+
+struct ResolvedUserAuthenticationAlgorithm {
+    var name: String
+    var signaturePrefix: String
+}
+
+extension NIOSSHPublicKey {
+    static func isKnownUserAuthenticationAlgorithm(_ name: String) -> Bool {
+        let bundledNames = [
+            String(Self.ed25519PublicKeyPrefix),
+            String(Self.ecdsaP256PublicKeyPrefix),
+            String(Self.ecdsaP384PublicKeyPrefix),
+            String(Self.ecdsaP521PublicKeyPrefix),
+            String(NIOSSHCertifiedPublicKey.ed25519KeyPrefix),
+            String(NIOSSHCertifiedPublicKey.p256KeyPrefix),
+            String(NIOSSHCertifiedPublicKey.p384KeyPrefix),
+            String(NIOSSHCertifiedPublicKey.p521KeyPrefix),
+        ]
+        if bundledNames.contains(name) {
+            return true
+        }
+
+        return self.customPublicKeyAlgorithmRegistrations.contains { registration in
+            let algorithm = registration.userAuthenticationAlgorithm
+            if algorithm.name == name
+                || algorithm.aliases.contains(name)
+            {
+                return true
+            }
+            guard let certificate = algorithm.certificate else {
+                return false
+            }
+            return certificate.name == name
+                || certificate.aliases.contains(name)
+        }
+    }
+
+    func userAuthenticationAlgorithm(
+        forAlgorithmIdentifier algorithmIdentifier: String
+    ) -> ResolvedUserAuthenticationAlgorithm? {
+        switch self.backingKey {
+        case .ed25519:
+            return algorithmIdentifier == String(Self.ed25519PublicKeyPrefix)
+                ? .init(name: String(Self.ed25519PublicKeyPrefix), signaturePrefix: algorithmIdentifier)
+                : nil
+        case .ecdsaP256:
+            return algorithmIdentifier == String(Self.ecdsaP256PublicKeyPrefix)
+                ? .init(name: String(Self.ecdsaP256PublicKeyPrefix), signaturePrefix: algorithmIdentifier)
+                : nil
+        case .ecdsaP384:
+            return algorithmIdentifier == String(Self.ecdsaP384PublicKeyPrefix)
+                ? .init(name: String(Self.ecdsaP384PublicKeyPrefix), signaturePrefix: algorithmIdentifier)
+                : nil
+        case .ecdsaP521:
+            return algorithmIdentifier == String(Self.ecdsaP521PublicKeyPrefix)
+                ? .init(name: String(Self.ecdsaP521PublicKeyPrefix), signaturePrefix: algorithmIdentifier)
+                : nil
+        case .custom(let key):
+            return Self.registrations(for: key).lazy.compactMap { registration in
+                let algorithm = registration.userAuthenticationAlgorithm
+                guard algorithm.name == algorithmIdentifier
+                    || algorithm.aliases.contains(algorithmIdentifier)
+                else {
+                    return nil
+                }
+                return .init(
+                    name: algorithm.name,
+                    signaturePrefix: registration.signature.signaturePrefix
+                )
+            }.first
+        case .certified(let certificate):
+            switch certificate.key.backingKey {
+            case .custom(let key):
+                return Self.registrations(for: key).lazy.compactMap { registration in
+                    let algorithm = registration.userAuthenticationAlgorithm
+                    guard algorithm.name == algorithmIdentifier
+                        || algorithm.aliases.contains(algorithmIdentifier),
+                        let certificateAlgorithm = algorithm.certificate
+                    else {
+                        return nil
+                    }
+                    return .init(
+                        name: certificateAlgorithm.name,
+                        signaturePrefix: registration.signature.signaturePrefix
+                    )
+                }.first
+            case .ed25519:
+                return algorithmIdentifier == String(Self.ed25519PublicKeyPrefix)
+                    ? .init(name: String(NIOSSHCertifiedPublicKey.ed25519KeyPrefix), signaturePrefix: algorithmIdentifier)
+                    : nil
+            case .ecdsaP256:
+                return algorithmIdentifier == String(Self.ecdsaP256PublicKeyPrefix)
+                    ? .init(name: String(NIOSSHCertifiedPublicKey.p256KeyPrefix), signaturePrefix: algorithmIdentifier)
+                    : nil
+            case .ecdsaP384:
+                return algorithmIdentifier == String(Self.ecdsaP384PublicKeyPrefix)
+                    ? .init(name: String(NIOSSHCertifiedPublicKey.p384KeyPrefix), signaturePrefix: algorithmIdentifier)
+                    : nil
+            case .ecdsaP521:
+                return algorithmIdentifier == String(Self.ecdsaP521PublicKeyPrefix)
+                    ? .init(name: String(NIOSSHCertifiedPublicKey.p521KeyPrefix), signaturePrefix: algorithmIdentifier)
+                    : nil
+            case .certified:
+                preconditionFailure("base key cannot be certified")
+            }
+        }
+    }
+
+    func userAuthenticationAlgorithm(
+        named name: String
+    ) -> ResolvedUserAuthenticationAlgorithm? {
+        switch self.backingKey {
+        case .ed25519:
+            return name == String(Self.ed25519PublicKeyPrefix)
+                ? .init(name: name, signaturePrefix: name)
+                : nil
+        case .ecdsaP256:
+            return name == String(Self.ecdsaP256PublicKeyPrefix)
+                ? .init(name: name, signaturePrefix: name)
+                : nil
+        case .ecdsaP384:
+            return name == String(Self.ecdsaP384PublicKeyPrefix)
+                ? .init(name: name, signaturePrefix: name)
+                : nil
+        case .ecdsaP521:
+            return name == String(Self.ecdsaP521PublicKeyPrefix)
+                ? .init(name: name, signaturePrefix: name)
+                : nil
+        case .custom(let key):
+            return Self.registrations(for: key).lazy.compactMap { registration in
+                let algorithm = registration.userAuthenticationAlgorithm
+                guard algorithm.name == name
+                    || algorithm.aliases.contains(name)
+                else {
+                    return nil
+                }
+                return .init(name: name, signaturePrefix: registration.signature.signaturePrefix)
+            }.first
+        case .certified(let certificate):
+            switch certificate.key.backingKey {
+            case .custom(let key):
+                return Self.registrations(for: key).lazy.compactMap { registration in
+                    guard let certificateAlgorithm = registration.userAuthenticationAlgorithm.certificate,
+                        certificateAlgorithm.name == name
+                            || certificateAlgorithm.aliases.contains(name)
+                    else {
+                        return nil
+                    }
+                    return .init(name: name, signaturePrefix: registration.signature.signaturePrefix)
+                }.first
+            case .ed25519:
+                return name == String(NIOSSHCertifiedPublicKey.ed25519KeyPrefix)
+                    ? .init(name: name, signaturePrefix: String(Self.ed25519PublicKeyPrefix))
+                    : nil
+            case .ecdsaP256:
+                return name == String(NIOSSHCertifiedPublicKey.p256KeyPrefix)
+                    ? .init(name: name, signaturePrefix: String(Self.ecdsaP256PublicKeyPrefix))
+                    : nil
+            case .ecdsaP384:
+                return name == String(NIOSSHCertifiedPublicKey.p384KeyPrefix)
+                    ? .init(name: name, signaturePrefix: String(Self.ecdsaP384PublicKeyPrefix))
+                    : nil
+            case .ecdsaP521:
+                return name == String(NIOSSHCertifiedPublicKey.p521KeyPrefix)
+                    ? .init(name: name, signaturePrefix: String(Self.ecdsaP521PublicKeyPrefix))
+                    : nil
+            case .certified:
+                preconditionFailure("base key cannot be certified")
+            }
+        }
+    }
+
+    static func certificatePublicKeyPrefix(for key: NIOSSHPublicKeyProtocol) -> String? {
+        self.registrations(for: key).lazy.compactMap {
+            $0.userAuthenticationAlgorithm.certificate?.publicKeyPrefix
+        }.first
+    }
+
+    static func basePublicKeyPrefix(forCertificatePublicKeyPrefix prefix: String) -> String? {
+        self.customPublicKeyAlgorithmRegistrations.lazy.compactMap { registration in
+            guard let certificate = registration.userAuthenticationAlgorithm.certificate,
+                certificate.publicKeyPrefix == prefix
+            else {
+                return nil
+            }
+            return registration.publicKey.publicKeyPrefix
+        }.first
+    }
+
+    private static func registrations(
+        for key: NIOSSHPublicKeyProtocol
+    ) -> [PublicKeyAlgorithmRegistration] {
+        let keyTypeIdentifier = ObjectIdentifier(type(of: key))
+        return self.customPublicKeyAlgorithmRegistrations.filter {
+            ObjectIdentifier($0.publicKey) == keyTypeIdentifier
         }
     }
 }
 
 public enum NIOSSHAlgorithms {
+    private static let bundledPublicKeyBlobPrefixes: Set<String> = [
+        String(NIOSSHPublicKey.ed25519PublicKeyPrefix),
+        String(NIOSSHPublicKey.ecdsaP256PublicKeyPrefix),
+        String(NIOSSHPublicKey.ecdsaP384PublicKeyPrefix),
+        String(NIOSSHPublicKey.ecdsaP521PublicKeyPrefix),
+        String(NIOSSHCertifiedPublicKey.ed25519KeyPrefix),
+        String(NIOSSHCertifiedPublicKey.p256KeyPrefix),
+        String(NIOSSHCertifiedPublicKey.p384KeyPrefix),
+        String(NIOSSHCertifiedPublicKey.p521KeyPrefix),
+    ]
+
+    private static let bundledSignaturePrefixes: Set<String> = [
+        "ssh-ed25519",
+        "ecdsa-sha2-nistp256",
+        "ecdsa-sha2-nistp384",
+        "ecdsa-sha2-nistp521",
+    ]
+
     public static func register(keyExchangeAlgorithm type: NIOSSHKeyExchangeAlgorithmProtocol.Type) {
         _CustomAlgorithms.keyExchangeAlgorithmsLock.withLockVoid {
             if !_CustomAlgorithms.keyExchangeAlgorithms.contains(where: { ObjectIdentifier($0) == ObjectIdentifier(type) }) {
@@ -245,10 +519,122 @@ public enum NIOSSHAlgorithms {
         publicKey type: PublicKey.Type,
         signature: Signature.Type
     ) {
-        _CustomAlgorithms.publicKeyAlgorithmsLock.withLockVoid {
-            if !_CustomAlgorithms.publicKeyAlgorithms.contains(where: { ObjectIdentifier($0) == ObjectIdentifier(type) }) {
-                _CustomAlgorithms.publicKeyAlgorithms.append(type)
-                _CustomAlgorithms.signatures.append(signature)
+        self.register(
+            publicKey: type,
+            signature: signature,
+            userAuthenticationAlgorithm: .init(name: PublicKey.publicKeyPrefix)
+        )
+    }
+
+    /// Registers a custom public-key format, signature format, and user-authentication mapping.
+    public static func register<
+        PublicKey: NIOSSHPublicKeyProtocol,
+        Signature: NIOSSHSignatureProtocol
+    >(
+        publicKey type: PublicKey.Type,
+        signature: Signature.Type,
+        userAuthenticationAlgorithm: NIOSSHUserAuthenticationAlgorithm
+    ) {
+        _CustomAlgorithms.publicKeyAlgorithmRegistrationsLock.withLockVoid {
+            let publicKeyTypeIdentifier = ObjectIdentifier(type)
+            let signatureTypeIdentifier = ObjectIdentifier(signature)
+            let signaturePrefix = Signature.signaturePrefix
+            precondition(
+                !signaturePrefix.isEmpty && !Self.bundledSignaturePrefixes.contains(signaturePrefix),
+                "Custom signature identifiers must be non-empty and must not overlap bundled algorithms"
+            )
+            let registrationsUsingSignaturePrefix = _CustomAlgorithms.publicKeyAlgorithmRegistrations.filter {
+                $0.signature.signaturePrefix == signaturePrefix
+            }
+            precondition(
+                registrationsUsingSignaturePrefix.allSatisfy { ObjectIdentifier($0.signature) == signatureTypeIdentifier },
+                "A signature identifier must use one globally consistent parser type"
+            )
+
+            let certificatePrefix = userAuthenticationAlgorithm.certificate?.publicKeyPrefix
+            let newBlobPrefixes = Set([PublicKey.publicKeyPrefix] + [certificatePrefix].compactMap { $0 })
+            precondition(
+                newBlobPrefixes.count == (certificatePrefix == nil ? 1 : 2),
+                "A certificate and its base public key must use distinct blob identifiers"
+            )
+            precondition(
+                newBlobPrefixes.isDisjoint(with: Self.bundledPublicKeyBlobPrefixes),
+                "Custom public-key blob identifiers must not overlap bundled algorithms"
+            )
+            let otherRegisteredBlobPrefixes = Set(
+                _CustomAlgorithms.publicKeyAlgorithmRegistrations
+                    .filter { ObjectIdentifier($0.publicKey) != publicKeyTypeIdentifier }
+                    .flatMap { registration -> [String] in
+                        var prefixes = [registration.publicKey.publicKeyPrefix]
+                        if let certificatePrefix = registration.userAuthenticationAlgorithm.certificate?.publicKeyPrefix {
+                            prefixes.append(certificatePrefix)
+                        }
+                        return prefixes
+                    }
+            )
+            precondition(
+                newBlobPrefixes.isDisjoint(with: otherRegisteredBlobPrefixes),
+                "Custom public-key blob identifiers must be globally unique"
+            )
+
+            let plainAuthenticationNames = Set(
+                [userAuthenticationAlgorithm.name]
+                    + userAuthenticationAlgorithm.aliases
+            )
+            let certificateAuthenticationNames = Set(
+                [userAuthenticationAlgorithm.certificate?.name].compactMap { $0 }
+                    + (userAuthenticationAlgorithm.certificate?.aliases ?? [])
+            )
+            precondition(
+                !plainAuthenticationNames.contains("")
+                    && !certificateAuthenticationNames.contains("")
+                    && plainAuthenticationNames.isDisjoint(with: certificateAuthenticationNames),
+                "Plain and certificate user-authentication identifiers must be non-empty and distinct"
+            )
+            for registration in _CustomAlgorithms.publicKeyAlgorithmRegistrations
+            where ObjectIdentifier(registration.publicKey) == publicKeyTypeIdentifier
+                && registration.signature.signaturePrefix != signaturePrefix
+            {
+                let registeredPlainNames = Set(
+                    [registration.userAuthenticationAlgorithm.name]
+                        + registration.userAuthenticationAlgorithm.aliases
+                )
+                let registeredCertificateNames = Set(
+                    [registration.userAuthenticationAlgorithm.certificate?.name].compactMap { $0 }
+                        + (registration.userAuthenticationAlgorithm.certificate?.aliases ?? [])
+                )
+                precondition(
+                    plainAuthenticationNames.isDisjoint(with: registeredPlainNames)
+                        && certificateAuthenticationNames.isDisjoint(with: registeredCertificateNames),
+                    "A user-authentication identifier cannot select multiple signature algorithms"
+                )
+            }
+
+            if let certificatePrefix = userAuthenticationAlgorithm.certificate?.publicKeyPrefix {
+                let registeredPrefixes = _CustomAlgorithms.publicKeyAlgorithmRegistrations.compactMap { registration -> String? in
+                    guard ObjectIdentifier(registration.publicKey) == publicKeyTypeIdentifier else {
+                        return nil
+                    }
+                    return registration.userAuthenticationAlgorithm.certificate?.publicKeyPrefix
+                }
+                precondition(
+                    registeredPrefixes.allSatisfy { $0 == certificatePrefix },
+                    "All algorithms for a custom public key must use the same canonical certificate format"
+                )
+            }
+            let alreadyRegistered = _CustomAlgorithms.publicKeyAlgorithmRegistrations.contains { registration in
+                ObjectIdentifier(registration.publicKey) == publicKeyTypeIdentifier
+                    && ObjectIdentifier(registration.signature) == signatureTypeIdentifier
+                    && registration.userAuthenticationAlgorithm == userAuthenticationAlgorithm
+            }
+            if !alreadyRegistered {
+                _CustomAlgorithms.publicKeyAlgorithmRegistrations.append(
+                    .init(
+                        publicKey: type,
+                        signature: signature,
+                        userAuthenticationAlgorithm: userAuthenticationAlgorithm
+                    )
+                )
             }
         }
     }
@@ -258,11 +644,8 @@ public enum NIOSSHAlgorithms {
         _CustomAlgorithms.transportProtectionSchemesLock.withLockVoid {
             _CustomAlgorithms.transportProtectionSchemes = []
         }
-        _CustomAlgorithms.publicKeyAlgorithmsLock.withLockVoid {
-            _CustomAlgorithms.publicKeyAlgorithms = []
-        }
-        _CustomAlgorithms.signaturesLock.withLockVoid {
-            _CustomAlgorithms.signatures = []
+        _CustomAlgorithms.publicKeyAlgorithmRegistrationsLock.withLockVoid {
+            _CustomAlgorithms.publicKeyAlgorithmRegistrations = []
         }
         _CustomAlgorithms.keyExchangeAlgorithmsLock.withLockVoid {
             _CustomAlgorithms.keyExchangeAlgorithms = []
@@ -287,10 +670,8 @@ private enum _CustomAlgorithms {
     static var transportProtectionSchemes = [NIOSSHTransportProtection.Type]()
     static var keyExchangeAlgorithmsLock = NIOLock()
     static var keyExchangeAlgorithms = [NIOSSHKeyExchangeAlgorithmProtocol.Type]()
-    static var publicKeyAlgorithmsLock = NIOLock()
-    static var publicKeyAlgorithms: [NIOSSHPublicKeyProtocol.Type] = []
-    static var signaturesLock = NIOLock()
-    static var signatures: [NIOSSHSignatureProtocol.Type] = []
+    static var publicKeyAlgorithmRegistrationsLock = NIOLock()
+    static var publicKeyAlgorithmRegistrations: [PublicKeyAlgorithmRegistration] = []
 }
 
 extension NIOSSHPublicKey.BackingKey: Equatable {
@@ -422,9 +803,7 @@ extension ByteBuffer {
         case .ecdsaP521(let key):
             return self.writeECDSAP521PublicKey(baseKey: key)
         case .custom(let key):
-            var writtenBytes = writeSSHString(key.publicKeyPrefix.utf8)
-            writtenBytes += key.write(to: &self)
-            return writtenBytes
+            return key.write(to: &self)
         case .certified:
             preconditionFailure("Certified keys are the only callers of this method, and cannot contain themselves")
         }

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKey.swift
@@ -229,9 +229,13 @@ extension NIOSSHPublicKey {
 /// the signature blob. The public-key and signature formats come from `NIOSSHPublicKeyProtocol` and
 /// `NIOSSHSignatureProtocol`; this value supplies the user-authentication name and, when supported,
 /// the certificate-specific names.
-public struct NIOSSHUserAuthenticationAlgorithm: Hashable, Sendable {
+///
+/// Canonical names and aliases occupy one global user-authentication namespace. A name may only be
+/// reused when it selects the same public-key format, plain or certificate form, and signature
+/// procedure.
+public struct NIOSSHUserAuthenticationAlgorithm: Hashable {
     /// The certificate form of a user-authentication algorithm.
-    public struct Certificate: Hashable, Sendable {
+    public struct Certificate: Hashable {
         /// The canonical identifier written inside a certificate public-key blob.
         public var publicKeyPrefix: String
 
@@ -272,10 +276,75 @@ public struct NIOSSHUserAuthenticationAlgorithm: Hashable, Sendable {
     }
 }
 
+#if swift(>=5.5)
+extension NIOSSHUserAuthenticationAlgorithm: Sendable {}
+extension NIOSSHUserAuthenticationAlgorithm.Certificate: Sendable {}
+#endif
+
 struct PublicKeyAlgorithmRegistration {
     var publicKey: NIOSSHPublicKeyProtocol.Type
     var signature: NIOSSHSignatureProtocol.Type
     var userAuthenticationAlgorithm: NIOSSHUserAuthenticationAlgorithm
+}
+
+enum UserAuthenticationPublicKeyForm: Hashable {
+    case plain
+    case certificate
+}
+
+enum UserAuthenticationAlgorithmParserIdentity: Hashable {
+    case bundledEd25519
+    case bundledECDSAP256
+    case bundledECDSAP384
+    case bundledECDSAP521
+    case custom(ObjectIdentifier)
+}
+
+/// The meaning assigned to a user-authentication algorithm name.
+struct UserAuthenticationAlgorithmBinding: Hashable {
+    var publicKeyParser: UserAuthenticationAlgorithmParserIdentity
+    var publicKeyPrefix: String
+    var publicKeyForm: UserAuthenticationPublicKeyForm
+    var signatureParser: UserAuthenticationAlgorithmParserIdentity
+    var signaturePrefix: String
+}
+
+struct NamedUserAuthenticationAlgorithmBinding {
+    var names: [String]
+    var binding: UserAuthenticationAlgorithmBinding
+}
+
+extension PublicKeyAlgorithmRegistration {
+    var namedUserAuthenticationAlgorithmBindings: [NamedUserAuthenticationAlgorithmBinding] {
+        var bindings = [
+            NamedUserAuthenticationAlgorithmBinding(
+                names: [self.userAuthenticationAlgorithm.name] + self.userAuthenticationAlgorithm.aliases,
+                binding: .init(
+                    publicKeyParser: .custom(ObjectIdentifier(self.publicKey)),
+                    publicKeyPrefix: self.publicKey.publicKeyPrefix,
+                    publicKeyForm: .plain,
+                    signatureParser: .custom(ObjectIdentifier(self.signature)),
+                    signaturePrefix: self.signature.signaturePrefix
+                )
+            )
+        ]
+
+        if let certificate = self.userAuthenticationAlgorithm.certificate {
+            bindings.append(
+                .init(
+                    names: [certificate.name] + certificate.aliases,
+                    binding: .init(
+                        publicKeyParser: .custom(ObjectIdentifier(self.publicKey)),
+                        publicKeyPrefix: certificate.publicKeyPrefix,
+                        publicKeyForm: .certificate,
+                        signatureParser: .custom(ObjectIdentifier(self.signature)),
+                        signaturePrefix: self.signature.signaturePrefix
+                    )
+                )
+            )
+        }
+        return bindings
+    }
 }
 
 struct ResolvedUserAuthenticationAlgorithm {
@@ -285,33 +354,9 @@ struct ResolvedUserAuthenticationAlgorithm {
 
 extension NIOSSHPublicKey {
     static func isKnownUserAuthenticationAlgorithm(_ name: String) -> Bool {
-        let bundledNames = [
-            String(Self.ed25519PublicKeyPrefix),
-            String(Self.ecdsaP256PublicKeyPrefix),
-            String(Self.ecdsaP384PublicKeyPrefix),
-            String(Self.ecdsaP521PublicKeyPrefix),
-            String(NIOSSHCertifiedPublicKey.ed25519KeyPrefix),
-            String(NIOSSHCertifiedPublicKey.p256KeyPrefix),
-            String(NIOSSHCertifiedPublicKey.p384KeyPrefix),
-            String(NIOSSHCertifiedPublicKey.p521KeyPrefix),
-        ]
-        if bundledNames.contains(name) {
-            return true
-        }
-
-        return self.customPublicKeyAlgorithmRegistrations.contains { registration in
-            let algorithm = registration.userAuthenticationAlgorithm
-            if algorithm.name == name
-                || algorithm.aliases.contains(name)
-            {
-                return true
-            }
-            guard let certificate = algorithm.certificate else {
-                return false
-            }
-            return certificate.name == name
-                || certificate.aliases.contains(name)
-        }
+        NIOSSHAlgorithms.userAuthenticationAlgorithmBindings(
+            for: self.customPublicKeyAlgorithmRegistrations
+        )?[name] != nil
     }
 
     func userAuthenticationAlgorithm(
@@ -477,23 +522,122 @@ extension NIOSSHPublicKey {
 }
 
 public enum NIOSSHAlgorithms {
-    private static let bundledPublicKeyBlobPrefixes: Set<String> = [
-        String(NIOSSHPublicKey.ed25519PublicKeyPrefix),
-        String(NIOSSHPublicKey.ecdsaP256PublicKeyPrefix),
-        String(NIOSSHPublicKey.ecdsaP384PublicKeyPrefix),
-        String(NIOSSHPublicKey.ecdsaP521PublicKeyPrefix),
-        String(NIOSSHCertifiedPublicKey.ed25519KeyPrefix),
-        String(NIOSSHCertifiedPublicKey.p256KeyPrefix),
-        String(NIOSSHCertifiedPublicKey.p384KeyPrefix),
-        String(NIOSSHCertifiedPublicKey.p521KeyPrefix),
+    private static let bundledUserAuthenticationAlgorithmBindings: [NamedUserAuthenticationAlgorithmBinding] = [
+        .init(
+            names: [String(NIOSSHPublicKey.ed25519PublicKeyPrefix)],
+            binding: .init(
+                publicKeyParser: .bundledEd25519,
+                publicKeyPrefix: String(NIOSSHPublicKey.ed25519PublicKeyPrefix),
+                publicKeyForm: .plain,
+                signatureParser: .bundledEd25519,
+                signaturePrefix: String(NIOSSHPublicKey.ed25519PublicKeyPrefix)
+            )
+        ),
+        .init(
+            names: [String(NIOSSHPublicKey.ecdsaP256PublicKeyPrefix)],
+            binding: .init(
+                publicKeyParser: .bundledECDSAP256,
+                publicKeyPrefix: String(NIOSSHPublicKey.ecdsaP256PublicKeyPrefix),
+                publicKeyForm: .plain,
+                signatureParser: .bundledECDSAP256,
+                signaturePrefix: String(NIOSSHPublicKey.ecdsaP256PublicKeyPrefix)
+            )
+        ),
+        .init(
+            names: [String(NIOSSHPublicKey.ecdsaP384PublicKeyPrefix)],
+            binding: .init(
+                publicKeyParser: .bundledECDSAP384,
+                publicKeyPrefix: String(NIOSSHPublicKey.ecdsaP384PublicKeyPrefix),
+                publicKeyForm: .plain,
+                signatureParser: .bundledECDSAP384,
+                signaturePrefix: String(NIOSSHPublicKey.ecdsaP384PublicKeyPrefix)
+            )
+        ),
+        .init(
+            names: [String(NIOSSHPublicKey.ecdsaP521PublicKeyPrefix)],
+            binding: .init(
+                publicKeyParser: .bundledECDSAP521,
+                publicKeyPrefix: String(NIOSSHPublicKey.ecdsaP521PublicKeyPrefix),
+                publicKeyForm: .plain,
+                signatureParser: .bundledECDSAP521,
+                signaturePrefix: String(NIOSSHPublicKey.ecdsaP521PublicKeyPrefix)
+            )
+        ),
+        .init(
+            names: [String(NIOSSHCertifiedPublicKey.ed25519KeyPrefix)],
+            binding: .init(
+                publicKeyParser: .bundledEd25519,
+                publicKeyPrefix: String(NIOSSHCertifiedPublicKey.ed25519KeyPrefix),
+                publicKeyForm: .certificate,
+                signatureParser: .bundledEd25519,
+                signaturePrefix: String(NIOSSHPublicKey.ed25519PublicKeyPrefix)
+            )
+        ),
+        .init(
+            names: [String(NIOSSHCertifiedPublicKey.p256KeyPrefix)],
+            binding: .init(
+                publicKeyParser: .bundledECDSAP256,
+                publicKeyPrefix: String(NIOSSHCertifiedPublicKey.p256KeyPrefix),
+                publicKeyForm: .certificate,
+                signatureParser: .bundledECDSAP256,
+                signaturePrefix: String(NIOSSHPublicKey.ecdsaP256PublicKeyPrefix)
+            )
+        ),
+        .init(
+            names: [String(NIOSSHCertifiedPublicKey.p384KeyPrefix)],
+            binding: .init(
+                publicKeyParser: .bundledECDSAP384,
+                publicKeyPrefix: String(NIOSSHCertifiedPublicKey.p384KeyPrefix),
+                publicKeyForm: .certificate,
+                signatureParser: .bundledECDSAP384,
+                signaturePrefix: String(NIOSSHPublicKey.ecdsaP384PublicKeyPrefix)
+            )
+        ),
+        .init(
+            names: [String(NIOSSHCertifiedPublicKey.p521KeyPrefix)],
+            binding: .init(
+                publicKeyParser: .bundledECDSAP521,
+                publicKeyPrefix: String(NIOSSHCertifiedPublicKey.p521KeyPrefix),
+                publicKeyForm: .certificate,
+                signatureParser: .bundledECDSAP521,
+                signaturePrefix: String(NIOSSHPublicKey.ecdsaP521PublicKeyPrefix)
+            )
+        ),
     ]
 
-    private static let bundledSignaturePrefixes: Set<String> = [
-        "ssh-ed25519",
-        "ecdsa-sha2-nistp256",
-        "ecdsa-sha2-nistp384",
-        "ecdsa-sha2-nistp521",
-    ]
+    private static let bundledPublicKeyBlobPrefixes = Set(
+        Self.bundledUserAuthenticationAlgorithmBindings.map { $0.binding.publicKeyPrefix }
+    )
+
+    private static let bundledSignaturePrefixes = Set(
+        Self.bundledUserAuthenticationAlgorithmBindings.map { $0.binding.signaturePrefix }
+    )
+
+    static func validatedUserAuthenticationAlgorithmBindings(
+        customBindings: [NamedUserAuthenticationAlgorithmBinding]
+    ) -> [String: UserAuthenticationAlgorithmBinding]? {
+        var bindings: [String: UserAuthenticationAlgorithmBinding] = [:]
+        for namedBinding in Self.bundledUserAuthenticationAlgorithmBindings + customBindings {
+            guard !namedBinding.names.isEmpty, !namedBinding.names.contains("") else {
+                return nil
+            }
+            for name in namedBinding.names {
+                if let existingBinding = bindings[name], existingBinding != namedBinding.binding {
+                    return nil
+                }
+                bindings[name] = namedBinding.binding
+            }
+        }
+        return bindings
+    }
+
+    static func userAuthenticationAlgorithmBindings(
+        for registrations: [PublicKeyAlgorithmRegistration]
+    ) -> [String: UserAuthenticationAlgorithmBinding]? {
+        Self.validatedUserAuthenticationAlgorithmBindings(
+            customBindings: registrations.flatMap { $0.namedUserAuthenticationAlgorithmBindings }
+        )
+    }
 
     public static func register(keyExchangeAlgorithm type: NIOSSHKeyExchangeAlgorithmProtocol.Type) {
         _CustomAlgorithms.keyExchangeAlgorithmsLock.withLockVoid {
@@ -539,6 +683,11 @@ public enum NIOSSHAlgorithms {
             let publicKeyTypeIdentifier = ObjectIdentifier(type)
             let signatureTypeIdentifier = ObjectIdentifier(signature)
             let signaturePrefix = Signature.signaturePrefix
+            let newRegistration = PublicKeyAlgorithmRegistration(
+                publicKey: type,
+                signature: signature,
+                userAuthenticationAlgorithm: userAuthenticationAlgorithm
+            )
             precondition(
                 !signaturePrefix.isEmpty && !Self.bundledSignaturePrefixes.contains(signaturePrefix),
                 "Custom signature identifiers must be non-empty and must not overlap bundled algorithms"
@@ -591,24 +740,12 @@ public enum NIOSSHAlgorithms {
                     && plainAuthenticationNames.isDisjoint(with: certificateAuthenticationNames),
                 "Plain and certificate user-authentication identifiers must be non-empty and distinct"
             )
-            for registration in _CustomAlgorithms.publicKeyAlgorithmRegistrations
-            where ObjectIdentifier(registration.publicKey) == publicKeyTypeIdentifier
-                && registration.signature.signaturePrefix != signaturePrefix
-            {
-                let registeredPlainNames = Set(
-                    [registration.userAuthenticationAlgorithm.name]
-                        + registration.userAuthenticationAlgorithm.aliases
-                )
-                let registeredCertificateNames = Set(
-                    [registration.userAuthenticationAlgorithm.certificate?.name].compactMap { $0 }
-                        + (registration.userAuthenticationAlgorithm.certificate?.aliases ?? [])
-                )
-                precondition(
-                    plainAuthenticationNames.isDisjoint(with: registeredPlainNames)
-                        && certificateAuthenticationNames.isDisjoint(with: registeredCertificateNames),
-                    "A user-authentication identifier cannot select multiple signature algorithms"
-                )
-            }
+            precondition(
+                Self.userAuthenticationAlgorithmBindings(
+                    for: _CustomAlgorithms.publicKeyAlgorithmRegistrations + [newRegistration]
+                ) != nil,
+                "A user-authentication identifier must resolve to one key format, key form, and signature algorithm"
+            )
 
             if let certificatePrefix = userAuthenticationAlgorithm.certificate?.publicKeyPrefix {
                 let registeredPrefixes = _CustomAlgorithms.publicKeyAlgorithmRegistrations.compactMap { registration -> String? in
@@ -628,13 +765,7 @@ public enum NIOSSHAlgorithms {
                     && registration.userAuthenticationAlgorithm == userAuthenticationAlgorithm
             }
             if !alreadyRegistered {
-                _CustomAlgorithms.publicKeyAlgorithmRegistrations.append(
-                    .init(
-                        publicKey: type,
-                        signature: signature,
-                        userAuthenticationAlgorithm: userAuthenticationAlgorithm
-                    )
-                )
+                _CustomAlgorithms.publicKeyAlgorithmRegistrations.append(newRegistration)
             }
         }
     }

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHSignature.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHSignature.swift
@@ -55,6 +55,21 @@ extension NIOSSHSignature {
 
     /// The prefix of a P521 ECDSA public key.
     fileprivate static let ecdsaP521SignaturePrefix = "ecdsa-sha2-nistp521".utf8
+
+    var signaturePrefix: String {
+        switch self.backingSignature {
+        case .ed25519:
+            return String(Self.ed25519SignaturePrefix)
+        case .ecdsaP256:
+            return String(Self.ecdsaP256SignaturePrefix)
+        case .ecdsaP384:
+            return String(Self.ecdsaP384SignaturePrefix)
+        case .ecdsaP521:
+            return String(Self.ecdsaP521SignaturePrefix)
+        case .custom(let signature):
+            return signature.signaturePrefix
+        }
+    }
 }
 
 extension NIOSSHSignature.BackingSignature.RawBytes: Equatable {
@@ -87,7 +102,8 @@ extension NIOSSHSignature.BackingSignature: Equatable {
         case (.ecdsaP521(let lhs), .ecdsaP521(let rhs)):
             return lhs.rawRepresentation == rhs.rawRepresentation
         case (.custom(let lhs), .custom(let rhs)):
-            return lhs.rawRepresentation == rhs.rawRepresentation
+            return lhs.signaturePrefix == rhs.signaturePrefix
+                && lhs.rawRepresentation == rhs.rawRepresentation
         case (.ed25519, _),
              (.ecdsaP256, _),
              (.ecdsaP384, _),

--- a/Sources/NIOSSH/NIOSSHHandler.swift
+++ b/Sources/NIOSSH/NIOSSHHandler.swift
@@ -77,8 +77,10 @@ public final class NIOSSHHandler {
     }
 }
 
+#if swift(>=5.5)
 @available(*, unavailable)
 extension NIOSSHHandler: Sendable {}
+#endif
 
 extension NIOSSHHandler {
     enum PendingGlobalRequestResponse {

--- a/Sources/NIOSSH/SSHMessages.swift
+++ b/Sources/NIOSSH/SSHMessages.swift
@@ -149,8 +149,20 @@ extension SSHMessage {
         }
 
         enum PublicKeyAuthType: Equatable {
-            case known(key: NIOSSHPublicKey, signature: NIOSSHSignature?)
+            case known(
+                authenticationAlgorithm: String,
+                key: NIOSSHPublicKey,
+                signature: NIOSSHSignature?
+            )
             case unknown
+
+            static func known(key: NIOSSHPublicKey, signature: NIOSSHSignature?) -> Self {
+                .known(
+                    authenticationAlgorithm: String(key.keyPrefix),
+                    key: key,
+                    signature: signature
+                )
+            }
         }
 
         var username: String
@@ -185,7 +197,17 @@ extension SSHMessage {
         // SSH_MSG_USERAUTH_PK_OK
         static let id: UInt8 = 60
 
+        var authenticationAlgorithm: String
         var key: NIOSSHPublicKey
+
+        init(authenticationAlgorithm: String, key: NIOSSHPublicKey) {
+            self.authenticationAlgorithm = authenticationAlgorithm
+            self.key = key
+        }
+
+        init(key: NIOSSHPublicKey) {
+            self.init(authenticationAlgorithm: String(key.keyPrefix), key: key)
+        }
     }
 
     struct GlobalRequestMessage: Equatable {
@@ -679,30 +701,54 @@ extension ByteBuffer {
             case "publickey":
                 guard
                     let expectSignature = self.readSSHBoolean(),
-                    let algorithmName = self.readSSHString(),
+                    let authenticationAlgorithmBytes = self.readSSHString(),
                     var keyBytes = self.readSSHString()
                 else {
                     return nil
                 }
 
-                if NIOSSHPublicKey.knownAlgorithms.contains(where: { $0.elementsEqual(algorithmName.readableBytesView) }) {
+                let authenticationAlgorithm = String(
+                    decoding: authenticationAlgorithmBytes.readableBytesView,
+                    as: UTF8.self
+                )
+                if NIOSSHPublicKey.isKnownUserAuthenticationAlgorithm(authenticationAlgorithm) {
                     // This is a known algorithm, we can load the key.
-                    guard let publicKey = try keyBytes.readSSHHostKey() else {
+                    guard let publicKey = try keyBytes.readSSHHostKey(), keyBytes.readableBytes == 0 else {
                         return nil
                     }
 
-                    guard algorithmName.readableBytesView.elementsEqual(publicKey.keyPrefix) else {
+                    guard let resolvedAlgorithm = publicKey.userAuthenticationAlgorithm(named: authenticationAlgorithm) else {
                         throw NIOSSHError.invalidSSHMessage(reason: "algorithm and key mismatch in user auth request")
                     }
 
                     if expectSignature {
-                        guard var signatureBytes = self.readSSHString(), let signature = try signatureBytes.readSSHSignature() else {
+                        guard var signatureBytes = self.readSSHString(),
+                            let signature = try signatureBytes.readSSHSignature(),
+                            signatureBytes.readableBytes == 0
+                        else {
                             return nil
                         }
+                        guard signature.signaturePrefix == resolvedAlgorithm.signaturePrefix else {
+                            throw NIOSSHError.invalidSSHMessage(
+                                reason: "authentication algorithm and signature mismatch in user auth request"
+                            )
+                        }
 
-                        method = .publicKey(.known(key: publicKey, signature: signature))
+                        method = .publicKey(
+                            .known(
+                                authenticationAlgorithm: authenticationAlgorithm,
+                                key: publicKey,
+                                signature: signature
+                            )
+                        )
                     } else {
-                        method = .publicKey(.known(key: publicKey, signature: nil))
+                        method = .publicKey(
+                            .known(
+                                authenticationAlgorithm: authenticationAlgorithm,
+                                key: publicKey,
+                                signature: nil
+                            )
+                        )
                     }
                 } else {
                     // This is not an algorithm we know. Consume the signature if we're expecting it.
@@ -750,26 +796,30 @@ extension ByteBuffer {
     mutating func readUserAuthPKOKMessage() throws -> SSHMessage.UserAuthPKOKMessage? {
         try self.rewindOnNilOrError { `self` in
             guard
-                let publicKeyType = self.readSSHString(),
+                let authenticationAlgorithmBytes = self.readSSHString(),
                 var publicKeyBytes = self.readSSHString()
             else {
                 return nil
             }
 
-            guard NIOSSHPublicKey.knownAlgorithms.contains(where: { $0.elementsEqual(publicKeyType.readableBytesView) }) else {
+            let authenticationAlgorithm = String(
+                decoding: authenticationAlgorithmBytes.readableBytesView,
+                as: UTF8.self
+            )
+            guard NIOSSHPublicKey.isKnownUserAuthenticationAlgorithm(authenticationAlgorithm) else {
                 throw NIOSSHError.invalidSSHMessage(reason: "unsupported key type in PK_OK")
             }
 
-            guard let publicKey = try publicKeyBytes.readSSHHostKey() else {
+            guard let publicKey = try publicKeyBytes.readSSHHostKey(), publicKeyBytes.readableBytes == 0 else {
                 return nil
             }
 
             // Validate consistency here.
-            guard publicKeyType.readableBytesView.elementsEqual(publicKey.keyPrefix) else {
+            guard publicKey.userAuthenticationAlgorithm(named: authenticationAlgorithm) != nil else {
                 throw NIOSSHError.invalidSSHMessage(reason: "inconsistent key type")
             }
 
-            return .init(key: publicKey)
+            return .init(authenticationAlgorithm: authenticationAlgorithm, key: publicKey)
         }
     }
 
@@ -1301,10 +1351,16 @@ extension ByteBuffer {
             writtenBytes += self.writeSSHString("password".utf8)
             writtenBytes += self.writeSSHBoolean(false)
             writtenBytes += self.writeSSHString(password.utf8)
-        case .publicKey(.known(key: let key, signature: let signature)):
+        case .publicKey(
+            .known(
+                authenticationAlgorithm: let authenticationAlgorithm,
+                key: let key,
+                signature: let signature
+            )
+        ):
             writtenBytes += self.writeSSHString("publickey".utf8)
             writtenBytes += self.writeSSHBoolean(signature != nil)
-            writtenBytes += self.writeSSHString(key.keyPrefix)
+            writtenBytes += self.writeSSHString(authenticationAlgorithm.utf8)
             writtenBytes += self.writeCompositeSSHString { buffer in
                 buffer.writeSSHHostKey(key)
             }
@@ -1338,7 +1394,7 @@ extension ByteBuffer {
 
     mutating func writeUserAuthPKOKMessage(_ message: SSHMessage.UserAuthPKOKMessage) -> Int {
         var writtenBytes = 0
-        writtenBytes += self.writeSSHString(message.key.keyPrefix)
+        writtenBytes += self.writeSSHString(message.authenticationAlgorithm.utf8)
         writtenBytes += self.writeCompositeSSHString { buffer in
             buffer.writeSSHHostKey(message.key)
         }

--- a/Sources/NIOSSH/User Authentication/UserAuthSignablePayload.swift
+++ b/Sources/NIOSSH/User Authentication/UserAuthSignablePayload.swift
@@ -32,7 +32,13 @@ import NIOCore
 internal struct UserAuthSignablePayload {
     private(set) var bytes: ByteBuffer
 
-    init(sessionIdentifier: ByteBuffer, userName: String, serviceName: String, publicKey: NIOSSHPublicKey) {
+    init(
+        sessionIdentifier: ByteBuffer,
+        userName: String,
+        serviceName: String,
+        authenticationAlgorithm: String,
+        publicKey: NIOSSHPublicKey
+    ) {
         // We use the session identifier as the base buffer and just append to it. We ask for 1kB because it's likely
         // enough for this data.
         var sessionIdentifier = sessionIdentifier
@@ -45,7 +51,7 @@ internal struct UserAuthSignablePayload {
         newBuffer.writeSSHString(serviceName.utf8)
         newBuffer.writeSSHString("publickey".utf8)
         newBuffer.writeSSHBoolean(true)
-        newBuffer.writeSSHString(publicKey.keyPrefix)
+        newBuffer.writeSSHString(authenticationAlgorithm.utf8)
         newBuffer.writeCompositeSSHString { buffer in
             buffer.writeSSHHostKey(publicKey)
         }

--- a/Sources/NIOSSH/User Authentication/UserAuthenticationMethod.swift
+++ b/Sources/NIOSSH/User Authentication/UserAuthenticationMethod.swift
@@ -207,14 +207,31 @@ extension SSHMessage.UserAuthRequestMessage {
 
         switch request.offer {
         case .privateKey(let privateKeyRequest):
+            guard let authenticationAlgorithm = privateKeyRequest.publicKey.userAuthenticationAlgorithm(
+                forAlgorithmIdentifier: privateKeyRequest.privateKey.userAuthenticationAlgorithmIdentifier
+            ) else {
+                throw NIOSSHError.unknownSignature(
+                    algorithm: privateKeyRequest.privateKey.userAuthenticationAlgorithmIdentifier
+                )
+            }
             let dataToSign = UserAuthSignablePayload(
                 sessionIdentifier: sessionID,
                 userName: self.username,
                 serviceName: self.service,
+                authenticationAlgorithm: authenticationAlgorithm.name,
                 publicKey: privateKeyRequest.publicKey
             )
             let signature = try privateKeyRequest.privateKey.sign(dataToSign)
-            self.method = .publicKey(.known(key: privateKeyRequest.publicKey, signature: signature))
+            guard signature.signaturePrefix == authenticationAlgorithm.signaturePrefix else {
+                throw NIOSSHError.invalidUserAuthSignature
+            }
+            self.method = .publicKey(
+                .known(
+                    authenticationAlgorithm: authenticationAlgorithm.name,
+                    key: privateKeyRequest.publicKey,
+                    signature: signature
+                )
+            )
         case .password(let passwordRequest):
             self.method = .password(passwordRequest.password)
         case .hostBased:

--- a/Sources/NIOSSH/User Authentication/UserAuthenticationStateMachine.swift
+++ b/Sources/NIOSSH/User Authentication/UserAuthenticationStateMachine.swift
@@ -406,9 +406,21 @@ private extension UserAuthenticationStateMachine {
                 .init(outcome, supportedMethods: supportedMethods)
             }
 
-        case .publicKey(.known(key: let key, signature: .some(let signature))):
+        case .publicKey(
+            .known(
+                authenticationAlgorithm: let authenticationAlgorithm,
+                key: let key,
+                signature: .some(let signature)
+            )
+        ):
             // This is a direct request to auth, just pass it through.
-            let dataToSign = UserAuthSignablePayload(sessionIdentifier: sessionID, userName: request.username, serviceName: request.service, publicKey: key)
+            let dataToSign = UserAuthSignablePayload(
+                sessionIdentifier: sessionID,
+                userName: request.username,
+                serviceName: request.service,
+                authenticationAlgorithm: authenticationAlgorithm,
+                publicKey: key
+            )
             let supportedMethods = delegate.supportedAuthenticationMethods
 
             guard key.isValidSignature(signature, for: dataToSign) else {
@@ -451,7 +463,13 @@ private extension UserAuthenticationStateMachine {
                 .init(outcome, supportedMethods: supportedMethods)
             }
 
-        case .publicKey(.known(key: let key, signature: .none)):
+        case .publicKey(
+            .known(
+                authenticationAlgorithm: let authenticationAlgorithm,
+                key: let key,
+                signature: .none
+            )
+        ):
             // This is a weird wrinkle in public key auth: it's a request to ask whether a given key is valid, but not to validate that key itself.
             // For certificates, we should validate them before saying they're OK
             if let certifiedKey = NIOSSHCertifiedPublicKey(key),
@@ -466,14 +484,22 @@ private extension UserAuthenticationStateMachine {
                         acceptableCriticalOptions: config.acceptableCriticalOptions
                     )
                     // Certificate is valid
-                    return self.loop.makeSucceededFuture(.publicKeyOK(.init(key: key)))
+                    return self.loop.makeSucceededFuture(
+                        .publicKeyOK(
+                            .init(authenticationAlgorithm: authenticationAlgorithm, key: key)
+                        )
+                    )
                 } catch {
                     // Certificate validation failed, reject it
                     return self.loop.makeSucceededFuture(.failure(.init(authentications: delegate.supportedAuthenticationMethods.strings, partialSuccess: false)))
                 }
             }
             // For now we do a shortcut: we just say that all non-certificate keys are acceptable, rather than ask the delegate.
-            return self.loop.makeSucceededFuture(.publicKeyOK(.init(key: key)))
+            return self.loop.makeSucceededFuture(
+                .publicKeyOK(
+                    .init(authenticationAlgorithm: authenticationAlgorithm, key: key)
+                )
+            )
 
         case .publicKey(.unknown):
             // We don't known the algorithm, the auth attempt has failed.

--- a/Tests/NIOSSHTests/OpenSSHRSACertificateInteropTests.swift
+++ b/Tests/NIOSSHTests/OpenSSHRSACertificateInteropTests.swift
@@ -1,0 +1,319 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if os(macOS)
+import Foundation
+import NIOCore
+import NIOPosix
+@testable import NIOSSH
+import XCTest
+
+final class OpenSSHRSACertificateInteropTests: XCTestCase {
+    func testAuthenticatesToOpenSSHWithRSASHA256Certificate() throws {
+        let sshKeygen = "/usr/bin/ssh-keygen"
+        let sshd = "/usr/sbin/sshd"
+        let netcat = "/usr/bin/nc"
+        let openSSL = "/usr/bin/openssl"
+        for executable in [sshKeygen, sshd, netcat, openSSL]
+        where !FileManager.default.isExecutableFile(atPath: executable)
+        {
+            throw XCTSkip("OpenSSH interoperability tool is unavailable: \(executable)")
+        }
+
+        NIOSSHAlgorithms.unregisterAlgorithms()
+        TestRSAAlgorithms.registerSHA256()
+        defer { NIOSSHAlgorithms.unregisterAlgorithms() }
+
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nio-ssh-rsa-cert-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let hostKeyPath = temporaryDirectory.appendingPathComponent("host_key").path
+        let caKeyPath = temporaryDirectory.appendingPathComponent("ca_key").path
+        let userKeyPath = temporaryDirectory.appendingPathComponent("user_key").path
+        let username = NSUserName()
+
+        try self.run(sshKeygen, ["-q", "-t", "ed25519", "-N", "", "-f", hostKeyPath])
+        try self.run(sshKeygen, ["-q", "-t", "ed25519", "-N", "", "-f", caKeyPath])
+        try self.run(sshKeygen, ["-q", "-m", "PEM", "-t", "rsa", "-b", "2048", "-N", "", "-f", userKeyPath])
+        try self.run(
+            sshKeygen,
+            [
+                "-q", "-s", caKeyPath,
+                "-I", "nio-rsa-cert",
+                "-n", username,
+                "-V", "-1m:+10m",
+                "\(userKeyPath).pub",
+            ]
+        )
+
+        let certificateText = try String(contentsOfFile: "\(userKeyPath)-cert.pub", encoding: .utf8)
+        let certifiedPublicKey = try XCTUnwrap(
+            NIOSSHCertifiedPublicKey(
+                NIOSSHPublicKey(openSSHPublicKey: certificateText)
+            )
+        )
+        guard case .custom(let parsedPublicKey) = certifiedPublicKey.key.backingKey,
+            let rsaPublicKey = parsedPublicKey as? TestRSAPublicKey
+        else {
+            return XCTFail("expected the OpenSSH certificate to contain an RSA public key")
+        }
+        let privateKey = TestRSAPrivateKey(openSSLKeyPath: userKeyPath, publicKey: rsaPublicKey)
+
+        let caPublicKeyText = try String(contentsOfFile: "\(caKeyPath).pub", encoding: .utf8)
+        let caPublicKey = try NIOSSHPublicKey(openSSHPublicKey: caPublicKeyText)
+        XCTAssertNoThrow(
+            try certifiedPublicKey.validate(
+                principal: username,
+                type: .user,
+                allowedAuthoritySigningKeys: [caPublicKey]
+            )
+        )
+        XCTAssertEqual(String(certifiedPublicKey.keyPrefix), TestRSAAlgorithms.certificatePublicKeyPrefix)
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let port = try self.unusedLoopbackPort(group: group)
+
+        let daemon = Process()
+        let daemonErrorPipe = Pipe()
+        daemon.executableURL = URL(fileURLWithPath: sshd)
+        daemon.arguments = [
+            "-D", "-e", "-f", "/dev/null",
+            "-p", String(port),
+            "-h", hostKeyPath,
+            "-o", "ListenAddress=127.0.0.1",
+            "-o", "PidFile=\(temporaryDirectory.appendingPathComponent("sshd.pid").path)",
+            "-o", "AuthorizedKeysFile=none",
+            "-o", "TrustedUserCAKeys=\(caKeyPath).pub",
+            "-o", "StrictModes=no",
+            "-o", "PasswordAuthentication=no",
+            "-o", "KbdInteractiveAuthentication=no",
+            "-o", "UsePAM=no",
+            "-o", "PubkeyAuthentication=yes",
+            "-o", "PubkeyAcceptedAlgorithms=\(TestRSAAlgorithms.sha256Certificate)",
+            "-o", "CASignatureAlgorithms=ssh-ed25519",
+        ]
+        daemon.standardError = daemonErrorPipe
+        try daemon.run()
+        defer {
+            if daemon.isRunning {
+                daemon.terminate()
+            }
+            daemon.waitUntilExit()
+        }
+
+        guard self.waitUntilListening(netcat: netcat, port: port, daemon: daemon) else {
+            if daemon.isRunning {
+                daemon.terminate()
+                daemon.waitUntilExit()
+            }
+            let diagnostics = String(
+                decoding: daemonErrorPipe.fileHandleForReading.readDataToEndOfFile(),
+                as: UTF8.self
+            )
+            XCTFail("OpenSSH daemon did not start: \(diagnostics)")
+            return
+        }
+
+        let successPromise = group.next().makePromise(of: Void.self)
+        let authenticationDelegate = OpenSSHCertificateClientAuthDelegate(
+            username: username,
+            privateKey: .init(custom: privateKey),
+            certificate: certifiedPublicKey
+        )
+        let observer = OpenSSHAuthenticationObserver(successPromise: successPromise)
+        let bootstrap = ClientBootstrap(group: group)
+            .channelInitializer { channel in
+                channel.pipeline.addHandlers([
+                    NIOSSHHandler(
+                        role: .client(
+                            .init(
+                                userAuthDelegate: authenticationDelegate,
+                                serverAuthDelegate: OpenSSHAcceptAllHostKeysDelegate()
+                            )
+                        ),
+                        allocator: channel.allocator,
+                        inboundChildChannelInitializer: nil
+                    ),
+                    observer,
+                ])
+            }
+
+        let channel = try bootstrap.connect(host: "127.0.0.1", port: port).wait()
+        defer { try? channel.close().wait() }
+        let timeout = channel.eventLoop.scheduleTask(in: .seconds(10)) {
+            observer.failIfPending(OpenSSHInteropError.authenticationTimedOut)
+        }
+        defer { timeout.cancel() }
+
+        try successPromise.futureResult.wait()
+        XCTAssertEqual(authenticationDelegate.offerCount, 1)
+    }
+
+    private func unusedLoopbackPort(group: EventLoopGroup) throws -> Int {
+        let channel = try ServerBootstrap(group: group)
+            .childChannelInitializer { channel in
+                channel.eventLoop.makeSucceededVoidFuture()
+            }
+            .bind(host: "127.0.0.1", port: 0)
+            .wait()
+        defer { try? channel.close().wait() }
+        return try XCTUnwrap(channel.localAddress?.port)
+    }
+
+    @discardableResult
+    private func run(_ executable: String, _ arguments: [String]) throws -> String {
+        let process = Process()
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        try process.run()
+        process.waitUntilExit()
+        let standardOutput = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let standardError = errPipe.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0 else {
+            throw OpenSSHInteropError.processFailed(
+                executable,
+                process.terminationStatus,
+                String(decoding: standardError, as: UTF8.self)
+            )
+        }
+        return String(decoding: standardOutput, as: UTF8.self)
+    }
+
+    private func waitUntilListening(netcat: String, port: Int, daemon: Process) -> Bool {
+        for _ in 0..<100 {
+            guard daemon.isRunning else {
+                return false
+            }
+            let probe = Process()
+            probe.executableURL = URL(fileURLWithPath: netcat)
+            probe.arguments = ["-z", "127.0.0.1", String(port)]
+            probe.standardOutput = FileHandle.nullDevice
+            probe.standardError = FileHandle.nullDevice
+            try? probe.run()
+            probe.waitUntilExit()
+            if probe.terminationStatus == 0 {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        return false
+    }
+}
+
+private final class OpenSSHCertificateClientAuthDelegate: NIOSSHClientUserAuthenticationDelegate {
+    private let username: String
+    private let privateKey: NIOSSHPrivateKey
+    private let certificate: NIOSSHCertifiedPublicKey
+    private(set) var offerCount = 0
+
+    init(username: String, privateKey: NIOSSHPrivateKey, certificate: NIOSSHCertifiedPublicKey) {
+        self.username = username
+        self.privateKey = privateKey
+        self.certificate = certificate
+    }
+
+    func nextAuthenticationType(
+        availableMethods: NIOSSHAvailableUserAuthenticationMethods,
+        nextChallengePromise: EventLoopPromise<NIOSSHUserAuthenticationOffer?>
+    ) {
+        guard availableMethods.contains(.publicKey), self.offerCount == 0 else {
+            nextChallengePromise.succeed(nil)
+            return
+        }
+        self.offerCount += 1
+        nextChallengePromise.succeed(
+            .init(
+                username: self.username,
+                serviceName: "ssh-connection",
+                offer: .privateKey(
+                    .init(privateKey: self.privateKey, certifiedKey: self.certificate)
+                )
+            )
+        )
+    }
+}
+
+private struct OpenSSHAcceptAllHostKeysDelegate: NIOSSHClientServerAuthenticationDelegate {
+    func validateHostKey(
+        hostKey: NIOSSHPublicKey,
+        validationCompletePromise: EventLoopPromise<Void>
+    ) {
+        validationCompletePromise.succeed(())
+    }
+}
+
+private final class OpenSSHAuthenticationObserver: ChannelInboundHandler {
+    typealias InboundIn = Any
+
+    private let successPromise: EventLoopPromise<Void>
+    private var isComplete = false
+
+    init(successPromise: EventLoopPromise<Void>) {
+        self.successPromise = successPromise
+    }
+
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        if event is UserAuthSuccessEvent, !self.isComplete {
+            self.isComplete = true
+            self.successPromise.succeed(())
+        }
+        context.fireUserInboundEventTriggered(event)
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        self.failIfPending(error)
+        context.close(promise: nil)
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        self.failIfPending(OpenSSHInteropError.connectionClosed)
+        context.fireChannelInactive()
+    }
+
+    func failIfPending(_ error: Error) {
+        guard !self.isComplete else {
+            return
+        }
+        self.isComplete = true
+        self.successPromise.fail(error)
+    }
+}
+
+private enum OpenSSHInteropError: Error, CustomStringConvertible {
+    case processFailed(String, Int32, String)
+    case authenticationTimedOut
+    case connectionClosed
+
+    var description: String {
+        switch self {
+        case .processFailed(let executable, let status, let diagnostics):
+            return "\(executable) exited with status \(status): \(diagnostics)"
+        case .authenticationTimedOut:
+            return "OpenSSH authentication timed out"
+        case .connectionClosed:
+            return "OpenSSH closed the connection before authentication succeeded"
+        }
+    }
+}
+#endif

--- a/Tests/NIOSSHTests/RSACertificateAuthenticationTests.swift
+++ b/Tests/NIOSSHTests/RSACertificateAuthenticationTests.swift
@@ -1,0 +1,525 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import Foundation
+import NIOCore
+import NIOEmbedded
+@testable import NIOSSH
+import XCTest
+
+final class RSACertificateAuthenticationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        NIOSSHAlgorithms.unregisterAlgorithms()
+        TestRSAAlgorithms.registerSHA256()
+    }
+
+    override func tearDown() {
+        NIOSSHAlgorithms.unregisterAlgorithms()
+        super.tearDown()
+    }
+
+    func testRSACertificateUsesCanonicalBlobWithExponentAndModulusDirectly() throws {
+        let privateKey = try TestRSAPrivateKey()
+        let certificate = try self.makeCertificate(for: privateKey)
+        let publicKey = privateKey.backing
+
+        var encoded = ByteBufferAllocator().buffer(capacity: 1024)
+        encoded.writeSSHHostKey(NIOSSHPublicKey(certificate))
+        var fields = encoded
+
+        XCTAssertEqual(try XCTUnwrap(fields.readSSHStringAsString()), TestRSAAlgorithms.certificatePublicKeyPrefix)
+        XCTAssertEqual(fields.readSSHString(), certificate.nonce)
+        XCTAssertEqual(self.unsignedInteger(try XCTUnwrap(fields.readSSHString())), publicKey.exponent)
+        XCTAssertEqual(self.unsignedInteger(try XCTUnwrap(fields.readSSHString())), publicKey.modulus)
+        XCTAssertEqual(fields.readInteger(as: UInt64.self), certificate.serial)
+
+        let decoded = try XCTUnwrap(encoded.readSSHHostKey())
+        XCTAssertEqual(decoded, NIOSSHPublicKey(certificate))
+        XCTAssertEqual(encoded.readableBytes, 0)
+    }
+
+    func testSignedRSACertificateRequestHasThreeDistinctAlgorithmIdentifiers() throws {
+        let privateKey = try TestRSAPrivateKey()
+        let certificate = try self.makeCertificate(for: privateKey)
+        let sessionID = ByteBuffer(repeating: 0x5a, count: 32)
+        let offer = NIOSSHUserAuthenticationOffer(
+            username: "rsa-user",
+            serviceName: "ssh-connection",
+            offer: .privateKey(
+                .init(
+                    privateKey: .init(custom: privateKey),
+                    certifiedKey: certificate
+                )
+            )
+        )
+        let request = try SSHMessage.UserAuthRequestMessage(request: offer, sessionID: sessionID)
+        let message = SSHMessage.userAuthRequest(request)
+
+        guard case .publicKey(
+            .known(
+                authenticationAlgorithm: let authenticationAlgorithm,
+                key: let publicKey,
+                signature: .some(let signature)
+            )
+        ) = request.method else {
+            return XCTFail("expected signed public-key authentication")
+        }
+        XCTAssertEqual(authenticationAlgorithm, TestRSAAlgorithms.sha256Certificate)
+        XCTAssertEqual(String(publicKey.keyPrefix), TestRSAAlgorithms.certificatePublicKeyPrefix)
+        XCTAssertEqual(signature.signaturePrefix, TestRSAAlgorithms.sha256)
+
+        let payload = UserAuthSignablePayload(
+            sessionIdentifier: sessionID,
+            userName: request.username,
+            serviceName: request.service,
+            authenticationAlgorithm: authenticationAlgorithm,
+            publicKey: publicKey
+        )
+        XCTAssertTrue(publicKey.isValidSignature(signature, for: payload))
+
+        var packet = ByteBufferAllocator().buffer(capacity: 2048)
+        packet.writeSSHMessage(message)
+        var roundTripPacket = packet
+        let roundTripped = try XCTUnwrap(roundTripPacket.readSSHMessage())
+        XCTAssertEqual(roundTripped, message)
+
+        XCTAssertEqual(packet.readInteger(as: UInt8.self), SSHMessage.UserAuthRequestMessage.id)
+        XCTAssertEqual(packet.readSSHStringAsString(), "rsa-user")
+        XCTAssertEqual(packet.readSSHStringAsString(), "ssh-connection")
+        XCTAssertEqual(packet.readSSHStringAsString(), "publickey")
+        XCTAssertEqual(packet.readSSHBoolean(), true)
+        XCTAssertEqual(packet.readSSHStringAsString(), TestRSAAlgorithms.sha256Certificate)
+
+        var keyBlob = try XCTUnwrap(packet.readSSHString())
+        XCTAssertEqual(keyBlob.readSSHStringAsString(), TestRSAAlgorithms.certificatePublicKeyPrefix)
+
+        var signatureBlob = try XCTUnwrap(packet.readSSHString())
+        XCTAssertEqual(signatureBlob.readSSHStringAsString(), TestRSAAlgorithms.sha256)
+        let rawSignature = try XCTUnwrap(signatureBlob.readSSHString())
+        XCTAssertEqual(rawSignature.readableBytes, 256)
+        XCTAssertEqual(signatureBlob.readableBytes, 0, "signature algorithm must be framed exactly once")
+        XCTAssertEqual(packet.readableBytes, 0)
+    }
+
+    func testPlainAndCertificateRSARequestsRoundTripIndependently() throws {
+        let privateKey = try TestRSAPrivateKey()
+        let sessionID = ByteBuffer(repeating: 0x3c, count: 32)
+        let plainRequest = try SSHMessage.UserAuthRequestMessage(
+            request: .init(
+                username: "rsa-user",
+                serviceName: "ssh-connection",
+                offer: .privateKey(.init(privateKey: .init(custom: privateKey)))
+            ),
+            sessionID: sessionID
+        )
+        let certificateRequest = try SSHMessage.UserAuthRequestMessage(
+            request: .init(
+                username: "rsa-user",
+                serviceName: "ssh-connection",
+                offer: .privateKey(
+                    .init(
+                        privateKey: .init(custom: privateKey),
+                        certifiedKey: self.makeCertificate(for: privateKey)
+                    )
+                )
+            ),
+            sessionID: sessionID
+        )
+
+        XCTAssertEqual(plainRequest.authenticationAlgorithm, TestRSAAlgorithms.sha256)
+        XCTAssertEqual(certificateRequest.authenticationAlgorithm, TestRSAAlgorithms.sha256Certificate)
+        try self.assertMessageRoundTrips(.userAuthRequest(plainRequest))
+        try self.assertMessageRoundTrips(.userAuthRequest(certificateRequest))
+    }
+
+    func testCustomKeyCanUseDistinctUserAuthenticationAndHostSignatures() throws {
+        let privateKey = try ContextAwareTestRSAPrivateKey()
+        let request = try SSHMessage.UserAuthRequestMessage(
+            request: .init(
+                username: "rsa-user",
+                serviceName: "ssh-connection",
+                offer: .privateKey(.init(privateKey: .init(custom: privateKey)))
+            ),
+            sessionID: ByteBuffer(repeating: 0x2a, count: 32)
+        )
+
+        guard case .publicKey(
+            .known(authenticationAlgorithm: let algorithm, key: _, signature: let signature)
+        ) = request.method else {
+            return XCTFail("expected a signed public-key request")
+        }
+        XCTAssertEqual(algorithm, TestRSAAlgorithms.sha256)
+        XCTAssertEqual(signature?.signaturePrefix, TestRSAAlgorithms.sha256)
+
+        let hostSignature = try NIOSSHPrivateKey(custom: privateKey).sign(
+            digest: SHA256.hash(data: Data("host exchange hash".utf8))
+        )
+        XCTAssertEqual(hostSignature.signaturePrefix, TestRSAAlgorithms.publicKeyPrefix)
+    }
+
+    func testUserAuthenticationSignatureDefaultsToExistingSignatureMethod() throws {
+        let privateKey = try TestRSAPrivateKey()
+        let request = try SSHMessage.UserAuthRequestMessage(
+            request: .init(
+                username: "rsa-user",
+                serviceName: "ssh-connection",
+                offer: .privateKey(.init(privateKey: .init(custom: privateKey)))
+            ),
+            sessionID: ByteBuffer(repeating: 0x17, count: 32)
+        )
+
+        guard case .publicKey(
+            .known(authenticationAlgorithm: _, key: _, signature: let signature)
+        ) = request.method else {
+            return XCTFail("expected a signed public-key request")
+        }
+        XCTAssertEqual(signature?.signaturePrefix, TestRSAAlgorithms.sha256)
+    }
+
+    func testLegacyRegistrationPreservesThePublicKeyAuthenticationName() throws {
+        NIOSSHAlgorithms.unregisterAlgorithms()
+        NIOSSHAlgorithms.register(
+            publicKey: TestRSAPublicKey.self,
+            signature: TestRSASHA256Signature.self
+        )
+        let privateKey = LegacyPrefixedRSAPrivateKey(backing: try TestRSAPrivateKey())
+        let request = try SSHMessage.UserAuthRequestMessage(
+            request: .init(
+                username: "rsa-user",
+                serviceName: "ssh-connection",
+                offer: .privateKey(.init(privateKey: .init(custom: privateKey)))
+            ),
+            sessionID: ByteBuffer(repeating: 0x19, count: 32)
+        )
+
+        XCTAssertEqual(request.authenticationAlgorithm, TestRSAAlgorithms.publicKeyPrefix)
+        try self.assertMessageRoundTrips(.userAuthRequest(request))
+    }
+
+    func testSignaturePrefixDoesNotSelectUserAuthenticationAlgorithm() throws {
+        let authenticationName = "rsa-userauth-sha512"
+        let certificateAuthenticationName = "rsa-userauth-sha512-cert-v01@openssh.com"
+        NIOSSHAlgorithms.register(
+            publicKey: TestRSAPublicKey.self,
+            signature: TestRSASHA512Signature.self,
+            userAuthenticationAlgorithm: .init(
+                name: authenticationName,
+                certificate: .init(
+                    publicKeyPrefix: TestRSAAlgorithms.certificatePublicKeyPrefix,
+                    name: certificateAuthenticationName
+                )
+            )
+        )
+        let privateKey = try TestRSAPrivateKey()
+        let plainKey = NIOSSHPrivateKey(custom: privateKey).publicKey
+        let certificateKey = NIOSSHPublicKey(try self.makeCertificate(for: privateKey))
+
+        XCTAssertNil(
+            plainKey.userAuthenticationAlgorithm(
+                forAlgorithmIdentifier: TestRSAAlgorithms.sha512
+            )
+        )
+        XCTAssertNil(
+            certificateKey.userAuthenticationAlgorithm(
+                forAlgorithmIdentifier: TestRSAAlgorithms.sha512
+            )
+        )
+
+        let plainAlgorithm = try XCTUnwrap(
+            plainKey.userAuthenticationAlgorithm(forAlgorithmIdentifier: authenticationName)
+        )
+        XCTAssertEqual(plainAlgorithm.name, authenticationName)
+        XCTAssertEqual(plainAlgorithm.signaturePrefix, TestRSAAlgorithms.sha512)
+
+        let certificateAlgorithm = try XCTUnwrap(
+            certificateKey.userAuthenticationAlgorithm(forAlgorithmIdentifier: authenticationName)
+        )
+        XCTAssertEqual(certificateAlgorithm.name, certificateAuthenticationName)
+        XCTAssertEqual(certificateAlgorithm.signaturePrefix, TestRSAAlgorithms.sha512)
+    }
+
+    func testProbeAndPKOKPreserveCertificateAuthenticationName() throws {
+        let privateKey = try TestRSAPrivateKey()
+        let publicKey = NIOSSHPublicKey(try self.makeCertificate(for: privateKey))
+        let probe = SSHMessage.userAuthRequest(
+            .init(
+                username: "rsa-user",
+                service: "ssh-connection",
+                method: .publicKey(
+                    .known(
+                        authenticationAlgorithm: TestRSAAlgorithms.sha256Certificate,
+                        key: publicKey,
+                        signature: nil
+                    )
+                )
+            )
+        )
+        let response = SSHMessage.userAuthPKOK(
+            .init(
+                authenticationAlgorithm: TestRSAAlgorithms.sha256Certificate,
+                key: publicKey
+            )
+        )
+
+        try self.assertMessageRoundTrips(probe)
+        try self.assertMessageRoundTrips(response)
+
+        var packet = ByteBufferAllocator().buffer(capacity: 1024)
+        packet.writeSSHMessage(response)
+        XCTAssertEqual(packet.readInteger(as: UInt8.self), SSHMessage.UserAuthPKOKMessage.id)
+        XCTAssertEqual(packet.readSSHStringAsString(), TestRSAAlgorithms.sha256Certificate)
+        var keyBlob = try XCTUnwrap(packet.readSSHString())
+        XCTAssertEqual(keyBlob.readSSHStringAsString(), TestRSAAlgorithms.certificatePublicKeyPrefix)
+    }
+
+    func testParserSupportsMultipleRSAAuthenticationNamesForOneKeyFormat() throws {
+        TestRSAAlgorithms.registerSHA512Parser()
+        TestRSAAlgorithms.registerLegacyParser()
+        let privateKey = try TestRSAPrivateKey()
+        let certificateKey = NIOSSHPublicKey(try self.makeCertificate(for: privateKey))
+        let plainKey = NIOSSHPrivateKey(custom: privateKey).publicKey
+
+        let probes: [(String, NIOSSHPublicKey)] = [
+            (TestRSAAlgorithms.sha256, plainKey),
+            (TestRSAAlgorithms.sha512, plainKey),
+            (TestRSAAlgorithms.publicKeyPrefix, plainKey),
+            (TestRSAAlgorithms.sha256Certificate, certificateKey),
+            (TestRSAAlgorithms.sha512Certificate, certificateKey),
+            (TestRSAAlgorithms.certificatePublicKeyPrefix, certificateKey),
+        ]
+        for (algorithm, key) in probes {
+            try self.assertMessageRoundTrips(
+                .userAuthRequest(
+                    .init(
+                        username: "rsa-user",
+                        service: "ssh-connection",
+                        method: .publicKey(
+                            .known(
+                                authenticationAlgorithm: algorithm,
+                                key: key,
+                                signature: nil
+                            )
+                        )
+                    )
+                )
+            )
+        }
+
+        XCTAssertEqual(
+            Set(NIOSSHPublicKey.customSignatures.map { $0.signaturePrefix }),
+            [TestRSAAlgorithms.sha256, TestRSAAlgorithms.sha512, TestRSAAlgorithms.publicKeyPrefix]
+        )
+    }
+
+    func testParserRejectsRSAAlgorithmKeyAndSignatureMismatches() throws {
+        TestRSAAlgorithms.registerSHA512Parser()
+        let privateKey = try TestRSAPrivateKey()
+        let plainKey = NIOSSHPrivateKey(custom: privateKey).publicKey
+        let certificateKey = NIOSSHPublicKey(try self.makeCertificate(for: privateKey))
+
+        var wrongKeyPacket = ByteBufferAllocator().buffer(capacity: 1024)
+        wrongKeyPacket.writeInteger(SSHMessage.UserAuthRequestMessage.id)
+        wrongKeyPacket.writeSSHString("rsa-user".utf8)
+        wrongKeyPacket.writeSSHString("ssh-connection".utf8)
+        wrongKeyPacket.writeSSHString("publickey".utf8)
+        wrongKeyPacket.writeSSHBoolean(false)
+        wrongKeyPacket.writeSSHString(TestRSAAlgorithms.sha256Certificate.utf8)
+        wrongKeyPacket.writeCompositeSSHString { $0.writeSSHHostKey(plainKey) }
+        XCTAssertThrowsError(try wrongKeyPacket.readSSHMessage()) { error in
+            XCTAssertEqual((error as? NIOSSHError)?.type, .invalidSSHMessage)
+        }
+
+        var wrongSignaturePacket = ByteBufferAllocator().buffer(capacity: 2048)
+        wrongSignaturePacket.writeInteger(SSHMessage.UserAuthRequestMessage.id)
+        wrongSignaturePacket.writeSSHString("rsa-user".utf8)
+        wrongSignaturePacket.writeSSHString("ssh-connection".utf8)
+        wrongSignaturePacket.writeSSHString("publickey".utf8)
+        wrongSignaturePacket.writeSSHBoolean(true)
+        wrongSignaturePacket.writeSSHString(TestRSAAlgorithms.sha256Certificate.utf8)
+        wrongSignaturePacket.writeCompositeSSHString { $0.writeSSHHostKey(certificateKey) }
+        wrongSignaturePacket.writeCompositeSSHString {
+            $0.writeSSHSignature(
+                .init(
+                    backingSignature: .custom(
+                        TestRSASHA512Signature(rawRepresentation: Data(repeating: 0x42, count: 256))
+                    )
+                )
+            )
+        }
+        XCTAssertThrowsError(try wrongSignaturePacket.readSSHMessage()) { error in
+            XCTAssertEqual((error as? NIOSSHError)?.type, .invalidSSHMessage)
+        }
+    }
+
+    func testServerStateMachineVerifiesThePreservedCertificateAlgorithm() throws {
+        let privateKey = try TestRSAPrivateKey()
+        let certificateAndCA = try self.makeCertificateAndCA(for: privateKey)
+        let sessionID = ByteBuffer(repeating: 0x7e, count: 32)
+        let request = try SSHMessage.UserAuthRequestMessage(
+            request: .init(
+                username: "rsa-user",
+                serviceName: "ssh-connection",
+                offer: .privateKey(
+                    .init(
+                        privateKey: .init(custom: privateKey),
+                        certifiedKey: certificateAndCA.certificate
+                    )
+                )
+            ),
+            sessionID: sessionID
+        )
+
+        var packet = ByteBufferAllocator().buffer(capacity: 2048)
+        packet.writeSSHMessage(.userAuthRequest(request))
+        guard case .userAuthRequest(let parsedRequest) = try XCTUnwrap(packet.readSSHMessage()) else {
+            return XCTFail("expected a parsed user-auth request")
+        }
+        guard case .publicKey(
+            .known(
+                authenticationAlgorithm: let authenticationAlgorithm,
+                key: let parsedKey,
+                signature: .some(let parsedSignature)
+            )
+        ) = parsedRequest.method else {
+            return XCTFail("expected a signed public-key request")
+        }
+        let parsedCertificate = try XCTUnwrap(NIOSSHCertifiedPublicKey(parsedKey))
+        let parsedPayload = UserAuthSignablePayload(
+            sessionIdentifier: sessionID,
+            userName: parsedRequest.username,
+            serviceName: parsedRequest.service,
+            authenticationAlgorithm: authenticationAlgorithm,
+            publicKey: parsedKey
+        )
+        XCTAssertTrue(parsedKey.isValidSignature(parsedSignature, for: parsedPayload))
+        XCTAssertNoThrow(
+            try parsedCertificate.validate(
+                principal: "rsa-user",
+                type: .user,
+                allowedAuthoritySigningKeys: [certificateAndCA.caPublicKey]
+            )
+        )
+
+        let delegate = AcceptRSACertificateDelegate()
+        var configuration = SSHServerConfiguration(
+            hostKeys: [.init(ed25519Key: .init())],
+            userAuthDelegate: delegate
+        )
+        configuration.trustedUserCAKeys = [certificateAndCA.caPublicKey]
+        let loop = EmbeddedEventLoop()
+        var stateMachine = UserAuthenticationStateMachine(
+            role: .server(configuration),
+            loop: loop,
+            sessionID: sessionID
+        )
+        let serviceAccept = try XCTUnwrap(
+            stateMachine.receiveServiceRequest(.init(service: "ssh-userauth"))
+        )
+        stateMachine.sendServiceAccept(serviceAccept)
+
+        let response = try XCTUnwrap(stateMachine.receiveUserAuthRequest(parsedRequest))
+        let succeeded = response.map { result in
+            if case .success = result {
+                return true
+            }
+            return false
+        }
+        loop.run()
+
+        XCTAssertTrue(try succeeded.wait())
+        XCTAssertEqual(delegate.receivedCertificate, certificateAndCA.certificate)
+    }
+
+    private func makeCertificate(for privateKey: TestRSAPrivateKey) throws -> NIOSSHCertifiedPublicKey {
+        try self.makeCertificateAndCA(for: privateKey).certificate
+    }
+
+    private func makeCertificateAndCA(
+        for privateKey: TestRSAPrivateKey
+    ) throws -> (certificate: NIOSSHCertifiedPublicKey, caPublicKey: NIOSSHPublicKey) {
+        let caSigningKey = Curve25519.Signing.PrivateKey()
+        let caPrivateKey = NIOSSHPrivateKey(ed25519Key: caSigningKey)
+        let placeholderSignature = try caPrivateKey.sign(
+            digest: SHA256.hash(data: Data("certificate-placeholder".utf8))
+        )
+        var certificate = try NIOSSHCertifiedPublicKey(
+            nonce: ByteBuffer(repeating: 0xa5, count: 32),
+            serial: 42,
+            type: .user,
+            key: NIOSSHPrivateKey(custom: privateKey).publicKey,
+            keyID: "rsa-user",
+            validPrincipals: ["rsa-user"],
+            validAfter: 0,
+            validBefore: .max,
+            criticalOptions: [:],
+            extensions: ["permit-pty": ""],
+            signatureKey: caPrivateKey.publicKey,
+            signature: placeholderSignature
+        )
+        let signature = try caSigningKey.signature(
+            for: certificate.signableBytes.readableBytesView
+        )
+        certificate.signature = .init(backingSignature: .ed25519(.data(signature)))
+        return (certificate, caPrivateKey.publicKey)
+    }
+
+    private func assertMessageRoundTrips(
+        _ message: SSHMessage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        var packet = ByteBufferAllocator().buffer(capacity: 2048)
+        packet.writeSSHMessage(message)
+        XCTAssertEqual(try packet.readSSHMessage(), message, file: file, line: line)
+        XCTAssertEqual(packet.readableBytes, 0, file: file, line: line)
+    }
+
+    private func unsignedInteger(_ value: ByteBuffer) -> Data {
+        var bytes = Array(value.readableBytesView)
+        while bytes.count > 1 && bytes.first == 0 {
+            bytes.removeFirst()
+        }
+        return Data(bytes)
+    }
+}
+
+private final class AcceptRSACertificateDelegate: NIOSSHServerUserAuthenticationDelegate {
+    let supportedAuthenticationMethods: NIOSSHAvailableUserAuthenticationMethods = .publicKey
+    var receivedCertificate: NIOSSHCertifiedPublicKey?
+
+    func requestReceived(
+        request: NIOSSHUserAuthenticationRequest,
+        responsePromise: EventLoopPromise<NIOSSHUserAuthenticationOutcome>
+    ) {
+        guard case .publicKey(let publicKey) = request.request else {
+            responsePromise.succeed(.failure)
+            return
+        }
+        self.receivedCertificate = publicKey.certifiedKey
+        responsePromise.succeed(publicKey.certifiedKey == nil ? .failure : .success)
+    }
+}
+
+private extension SSHMessage.UserAuthRequestMessage {
+    var authenticationAlgorithm: String? {
+        guard case .publicKey(
+            .known(authenticationAlgorithm: let algorithm, key: _, signature: _)
+        ) = self.method else {
+            return nil
+        }
+        return algorithm
+    }
+}

--- a/Tests/NIOSSHTests/RSACertificateAuthenticationTests.swift
+++ b/Tests/NIOSSHTests/RSACertificateAuthenticationTests.swift
@@ -31,6 +31,31 @@ final class RSACertificateAuthenticationTests: XCTestCase {
         super.tearDown()
     }
 
+    func testRepeatedRegistrationsAndSharedCertificateFormatRemainValid() {
+        TestRSAAlgorithms.registerSHA256()
+        TestRSAAlgorithms.registerSHA512Parser()
+        TestRSAAlgorithms.registerSHA512Parser()
+        NIOSSHAlgorithms.register(
+            publicKey: TestRSAPublicKey.self,
+            signature: TestRSALegacySignature.self
+        )
+        NIOSSHAlgorithms.register(
+            publicKey: TestRSAPublicKey.self,
+            signature: TestRSALegacySignature.self
+        )
+
+        let registrations = NIOSSHPublicKey.customPublicKeyAlgorithmRegistrations
+        XCTAssertEqual(registrations.count, 3)
+        XCTAssertEqual(
+            Set(registrations.compactMap { $0.userAuthenticationAlgorithm.certificate?.publicKeyPrefix }),
+            [TestRSAAlgorithms.certificatePublicKeyPrefix]
+        )
+        XCTAssertEqual(
+            Set(registrations.compactMap { $0.userAuthenticationAlgorithm.certificate?.name }),
+            [TestRSAAlgorithms.sha256Certificate, TestRSAAlgorithms.sha512Certificate]
+        )
+    }
+
     func testRSACertificateUsesCanonicalBlobWithExponentAndModulusDirectly() throws {
         let privateKey = try TestRSAPrivateKey()
         let certificate = try self.makeCertificate(for: privateKey)

--- a/Tests/NIOSSHTests/RSATestSupport.swift
+++ b/Tests/NIOSSHTests/RSATestSupport.swift
@@ -1,0 +1,307 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import Foundation
+import NIOCore
+@testable import NIOSSH
+
+enum TestRSAAlgorithms {
+    static let publicKeyPrefix = "ssh-rsa"
+    static let certificatePublicKeyPrefix = "ssh-rsa-cert-v01@openssh.com"
+    static let sha256 = "rsa-sha2-256"
+    static let sha256Certificate = "rsa-sha2-256-cert-v01@openssh.com"
+    static let sha512 = "rsa-sha2-512"
+    static let sha512Certificate = "rsa-sha2-512-cert-v01@openssh.com"
+
+    static func registerSHA256() {
+        NIOSSHAlgorithms.register(
+            publicKey: TestRSAPublicKey.self,
+            signature: TestRSASHA256Signature.self,
+            userAuthenticationAlgorithm: .init(
+                name: self.sha256,
+                certificate: .init(
+                    publicKeyPrefix: self.certificatePublicKeyPrefix,
+                    name: self.sha256Certificate
+                )
+            )
+        )
+    }
+
+    static func registerSHA512Parser() {
+        NIOSSHAlgorithms.register(
+            publicKey: TestRSAPublicKey.self,
+            signature: TestRSASHA512Signature.self,
+            userAuthenticationAlgorithm: .init(
+                name: self.sha512,
+                certificate: .init(
+                    publicKeyPrefix: self.certificatePublicKeyPrefix,
+                    name: self.sha512Certificate
+                )
+            )
+        )
+    }
+
+    static func registerLegacyParser() {
+        NIOSSHAlgorithms.register(
+            publicKey: TestRSAPublicKey.self,
+            signature: TestRSALegacySignature.self,
+            userAuthenticationAlgorithm: .init(
+                name: self.publicKeyPrefix,
+                certificate: .init(
+                    publicKeyPrefix: self.certificatePublicKeyPrefix,
+                    name: self.certificatePublicKeyPrefix
+                )
+            )
+        )
+    }
+}
+
+struct TestRSAPublicKey: NIOSSHPublicKeyProtocol {
+    static let publicKeyPrefix = TestRSAAlgorithms.publicKeyPrefix
+
+    var exponent: Data
+    var modulus: Data
+
+    var rawRepresentation: Data {
+        var buffer = ByteBufferAllocator().buffer(capacity: self.exponent.count + self.modulus.count + 8)
+        buffer.writeSSHString(self.exponent)
+        buffer.writeSSHString(self.modulus)
+        return Data(buffer.readableBytesView)
+    }
+
+    init(exponent: Data, modulus: Data) {
+        self.exponent = Self.normalizedUnsignedInteger(exponent)
+        self.modulus = Self.normalizedUnsignedInteger(modulus)
+    }
+
+    func isValidSignature<D: DataProtocol>(
+        _ signature: NIOSSHSignatureProtocol,
+        for data: D
+    ) -> Bool {
+        guard let signature = signature as? TestRSASHA256Signature else {
+            return false
+        }
+        return signature.rawRepresentation == Self.testSignature(for: data)
+    }
+
+    func write(to buffer: inout ByteBuffer) -> Int {
+        var written = buffer.writePositiveMPInt(self.exponent)
+        written += buffer.writePositiveMPInt(self.modulus)
+        return written
+    }
+
+    static func read(from buffer: inout ByteBuffer) throws -> Self {
+        guard let exponent = buffer.readSSHString(), let modulus = buffer.readSSHString() else {
+            throw NIOSSHError.invalidSSHMessage(reason: "incomplete RSA public key")
+        }
+        return .init(
+            exponent: exponent.unsignedMPIntBytes,
+            modulus: modulus.unsignedMPIntBytes
+        )
+    }
+
+    static func testSignature<D: DataProtocol>(for data: D) -> Data {
+        let digest = SHA256.hash(data: data)
+        var signature = Data()
+        signature.reserveCapacity(256)
+        for _ in 0..<8 {
+            signature.append(contentsOf: digest)
+        }
+        return signature
+    }
+
+    private static func normalizedUnsignedInteger(_ value: Data) -> Data {
+        var bytes = Array(value)
+        while bytes.count > 1 && bytes.first == 0 {
+            bytes.removeFirst()
+        }
+        return Data(bytes)
+    }
+}
+
+struct TestRSAPrivateKey: NIOSSHPrivateKeyProtocol {
+    static let keyPrefix = TestRSAAlgorithms.publicKeyPrefix
+
+    var userAuthenticationAlgorithmIdentifier: String {
+        TestRSAAlgorithms.sha256
+    }
+
+    var backing: TestRSAPublicKey
+
+    #if os(macOS)
+    private var openSSLKeyPath: String?
+    #endif
+
+    init() throws {
+        self.backing = .init(
+            exponent: Data([0x01, 0x00, 0x01]),
+            modulus: Data([0x80] + Array(repeating: 0xa5, count: 255))
+        )
+        #if os(macOS)
+        self.openSSLKeyPath = nil
+        #endif
+    }
+
+    #if os(macOS)
+    init(openSSLKeyPath: String, publicKey: TestRSAPublicKey) {
+        self.backing = publicKey
+        self.openSSLKeyPath = openSSLKeyPath
+    }
+    #endif
+
+    var publicKey: NIOSSHPublicKeyProtocol {
+        self.backing
+    }
+
+    func signature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol {
+        #if os(macOS)
+        if let openSSLKeyPath = self.openSSLKeyPath {
+            return TestRSASHA256Signature(
+                rawRepresentation: try Self.openSSLSignature(for: data, keyPath: openSSLKeyPath)
+            )
+        }
+        #endif
+        return TestRSASHA256Signature(rawRepresentation: TestRSAPublicKey.testSignature(for: data))
+    }
+
+    #if os(macOS)
+    private static func openSSLSignature<D: DataProtocol>(for data: D, keyPath: String) throws -> Data {
+        let process = Process()
+        let inPipe = Pipe()
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/openssl")
+        process.arguments = ["dgst", "-sha256", "-sign", keyPath]
+        process.standardInput = inPipe
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        try process.run()
+        try inPipe.fileHandleForWriting.write(contentsOf: Data(data))
+        try inPipe.fileHandleForWriting.close()
+        process.waitUntilExit()
+        let signature = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let diagnostics = errPipe.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0 else {
+            throw TestRSAError.externalSigningFailed(
+                process.terminationStatus,
+                String(decoding: diagnostics, as: UTF8.self)
+            )
+        }
+        return signature
+    }
+    #endif
+}
+
+struct ContextAwareTestRSAPrivateKey: NIOSSHPrivateKeyProtocol {
+    static let keyPrefix = TestRSAAlgorithms.publicKeyPrefix
+
+    var userAuthenticationAlgorithmIdentifier: String {
+        TestRSAAlgorithms.sha256
+    }
+
+    var backing: TestRSAPrivateKey
+
+    init() throws {
+        self.backing = try .init()
+    }
+
+    var publicKey: NIOSSHPublicKeyProtocol {
+        self.backing.publicKey
+    }
+
+    func signature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol {
+        TestRSALegacySignature(rawRepresentation: TestRSAPublicKey.testSignature(for: data))
+    }
+
+    func userAuthenticationSignature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol {
+        try self.backing.signature(for: data)
+    }
+}
+
+struct LegacyPrefixedRSAPrivateKey: NIOSSHPrivateKeyProtocol {
+    static let keyPrefix = "test-rsa-private-key"
+
+    var backing: TestRSAPrivateKey
+
+    var publicKey: NIOSSHPublicKeyProtocol {
+        self.backing.publicKey
+    }
+
+    func signature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol {
+        try self.backing.signature(for: data)
+    }
+}
+
+struct TestRSASHA256Signature: NIOSSHSignatureProtocol {
+    static let signaturePrefix = TestRSAAlgorithms.sha256
+    var rawRepresentation: Data
+
+    func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeSSHString(self.rawRepresentation)
+    }
+
+    static func read(from buffer: inout ByteBuffer) throws -> Self {
+        guard let bytes = buffer.readSSHString() else {
+            throw NIOSSHError.invalidSSHMessage(reason: "incomplete RSA SHA-256 signature")
+        }
+        return .init(rawRepresentation: Data(bytes.readableBytesView))
+    }
+}
+
+struct TestRSASHA512Signature: NIOSSHSignatureProtocol {
+    static let signaturePrefix = TestRSAAlgorithms.sha512
+    var rawRepresentation: Data
+
+    func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeSSHString(self.rawRepresentation)
+    }
+
+    static func read(from buffer: inout ByteBuffer) throws -> Self {
+        guard let bytes = buffer.readSSHString() else {
+            throw NIOSSHError.invalidSSHMessage(reason: "incomplete RSA SHA-512 signature")
+        }
+        return .init(rawRepresentation: Data(bytes.readableBytesView))
+    }
+}
+
+struct TestRSALegacySignature: NIOSSHSignatureProtocol {
+    static let signaturePrefix = TestRSAAlgorithms.publicKeyPrefix
+    var rawRepresentation: Data
+
+    func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeSSHString(self.rawRepresentation)
+    }
+
+    static func read(from buffer: inout ByteBuffer) throws -> Self {
+        guard let bytes = buffer.readSSHString() else {
+            throw NIOSSHError.invalidSSHMessage(reason: "incomplete legacy RSA signature")
+        }
+        return .init(rawRepresentation: Data(bytes.readableBytesView))
+    }
+}
+
+private extension ByteBuffer {
+    var unsignedMPIntBytes: Data {
+        var bytes = Array(self.readableBytesView)
+        while bytes.count > 1 && bytes.first == 0 {
+            bytes.removeFirst()
+        }
+        return Data(bytes)
+    }
+}
+
+private enum TestRSAError: Error {
+    case externalSigningFailed(Int32, String)
+}

--- a/Tests/NIOSSHTests/UserAuthenticationAlgorithmRegistrationTests.swift
+++ b/Tests/NIOSSHTests/UserAuthenticationAlgorithmRegistrationTests.swift
@@ -1,0 +1,308 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import NIOSSH
+import XCTest
+
+final class UserAuthenticationAlgorithmRegistrationTests: XCTestCase {
+    private enum PublicKeyParserA {}
+    private enum PublicKeyParserB {}
+    private enum SignatureParserA {}
+    private enum SignatureParserB {}
+
+    private let unrelatedBinding = UserAuthenticationAlgorithmBinding(
+        publicKeyParser: .custom(ObjectIdentifier(PublicKeyParserA.self)),
+        publicKeyPrefix: "custom-key",
+        publicKeyForm: .plain,
+        signatureParser: .custom(ObjectIdentifier(SignatureParserA.self)),
+        signaturePrefix: "custom-signature"
+    )
+
+    func testBundledAuthenticationNamesRejectCustomCanonicalNamesAndAliases() {
+        let bundledNames = [
+            "ssh-ed25519",
+            "ecdsa-sha2-nistp256",
+            "ecdsa-sha2-nistp384",
+            "ecdsa-sha2-nistp521",
+            "ssh-ed25519-cert-v01@openssh.com",
+            "ecdsa-sha2-nistp256-cert-v01@openssh.com",
+            "ecdsa-sha2-nistp384-cert-v01@openssh.com",
+            "ecdsa-sha2-nistp521-cert-v01@openssh.com",
+        ]
+
+        for name in bundledNames {
+            XCTAssertNil(
+                NIOSSHAlgorithms.validatedUserAuthenticationAlgorithmBindings(
+                    customBindings: [.init(names: [name], binding: self.unrelatedBinding)]
+                ),
+                "custom canonical name should not shadow \(name)"
+            )
+            XCTAssertNil(
+                NIOSSHAlgorithms.validatedUserAuthenticationAlgorithmBindings(
+                    customBindings: [.init(names: ["custom-auth", name], binding: self.unrelatedBinding)]
+                ),
+                "custom alias should not shadow \(name)"
+            )
+        }
+    }
+
+    func testAuthenticationNameCannotSelectDifferentCustomKeyFormats() {
+        let first = NamedUserAuthenticationAlgorithmBinding(
+            names: ["shared-name"],
+            binding: .init(
+                publicKeyParser: .custom(ObjectIdentifier(PublicKeyParserA.self)),
+                publicKeyPrefix: "custom-key-a",
+                publicKeyForm: .plain,
+                signatureParser: .custom(ObjectIdentifier(SignatureParserA.self)),
+                signaturePrefix: "custom-signature-a"
+            )
+        )
+        let second = NamedUserAuthenticationAlgorithmBinding(
+            names: ["shared-name"],
+            binding: .init(
+                publicKeyParser: .custom(ObjectIdentifier(PublicKeyParserB.self)),
+                publicKeyPrefix: "custom-key-b",
+                publicKeyForm: .plain,
+                signatureParser: .custom(ObjectIdentifier(SignatureParserB.self)),
+                signaturePrefix: "custom-signature-b"
+            )
+        )
+
+        XCTAssertNil(
+            NIOSSHAlgorithms.validatedUserAuthenticationAlgorithmBindings(customBindings: [first, second])
+        )
+        XCTAssertNil(
+            NIOSSHAlgorithms.validatedUserAuthenticationAlgorithmBindings(customBindings: [second, first])
+        )
+    }
+
+    func testAuthenticationNameCannotSelectDifferentParsersBehindTheSamePrefixes() {
+        let original = NamedUserAuthenticationAlgorithmBinding(
+            names: ["shared-name"],
+            binding: self.unrelatedBinding
+        )
+        var differentPublicKeyParser = self.unrelatedBinding
+        differentPublicKeyParser.publicKeyParser = .custom(ObjectIdentifier(PublicKeyParserB.self))
+        var differentSignatureParser = self.unrelatedBinding
+        differentSignatureParser.signatureParser = .custom(ObjectIdentifier(SignatureParserB.self))
+
+        XCTAssertNil(
+            NIOSSHAlgorithms.validatedUserAuthenticationAlgorithmBindings(
+                customBindings: [
+                    original,
+                    .init(names: ["shared-name"], binding: differentPublicKeyParser),
+                ]
+            )
+        )
+        XCTAssertNil(
+            NIOSSHAlgorithms.validatedUserAuthenticationAlgorithmBindings(
+                customBindings: [
+                    original,
+                    .init(names: ["shared-name"], binding: differentSignatureParser),
+                ]
+            )
+        )
+    }
+
+    func testAuthenticationNameCannotSelectPlainAndCertificateForms() {
+        let plain = NamedUserAuthenticationAlgorithmBinding(
+            names: ["shared-name"],
+            binding: .init(
+                publicKeyParser: .custom(ObjectIdentifier(PublicKeyParserA.self)),
+                publicKeyPrefix: "custom-key",
+                publicKeyForm: .plain,
+                signatureParser: .custom(ObjectIdentifier(SignatureParserA.self)),
+                signaturePrefix: "custom-signature"
+            )
+        )
+        let certificate = NamedUserAuthenticationAlgorithmBinding(
+            names: ["shared-name"],
+            binding: .init(
+                publicKeyParser: .custom(ObjectIdentifier(PublicKeyParserA.self)),
+                publicKeyPrefix: "custom-key-cert-v01@example.com",
+                publicKeyForm: .certificate,
+                signatureParser: .custom(ObjectIdentifier(SignatureParserA.self)),
+                signaturePrefix: "custom-signature"
+            )
+        )
+
+        XCTAssertNil(
+            NIOSSHAlgorithms.validatedUserAuthenticationAlgorithmBindings(customBindings: [plain, certificate])
+        )
+        XCTAssertNil(
+            NIOSSHAlgorithms.validatedUserAuthenticationAlgorithmBindings(customBindings: [certificate, plain])
+        )
+    }
+
+    func testCanonicalNamesAndAliasesUseOneGlobalNamespace() {
+        let alias = NamedUserAuthenticationAlgorithmBinding(
+            names: ["algorithm-a", "shared-name"],
+            binding: .init(
+                publicKeyParser: .custom(ObjectIdentifier(PublicKeyParserA.self)),
+                publicKeyPrefix: "custom-key-a",
+                publicKeyForm: .certificate,
+                signatureParser: .custom(ObjectIdentifier(SignatureParserA.self)),
+                signaturePrefix: "custom-signature-a"
+            )
+        )
+        let canonical = NamedUserAuthenticationAlgorithmBinding(
+            names: ["shared-name"],
+            binding: .init(
+                publicKeyParser: .custom(ObjectIdentifier(PublicKeyParserB.self)),
+                publicKeyPrefix: "custom-key-b",
+                publicKeyForm: .plain,
+                signatureParser: .custom(ObjectIdentifier(SignatureParserB.self)),
+                signaturePrefix: "custom-signature-b"
+            )
+        )
+
+        XCTAssertNil(
+            NIOSSHAlgorithms.validatedUserAuthenticationAlgorithmBindings(customBindings: [alias, canonical])
+        )
+        XCTAssertNil(
+            NIOSSHAlgorithms.validatedUserAuthenticationAlgorithmBindings(customBindings: [canonical, alias])
+        )
+    }
+
+    func testRegistrationAdapterRejectsTheReportedCrossCategoryCollision() {
+        let first = PublicKeyAlgorithmRegistration(
+            publicKey: TestRSAPublicKey.self,
+            signature: TestRSASHA256Signature.self,
+            userAuthenticationAlgorithm: .init(
+                name: "algorithm-a",
+                certificate: .init(
+                    publicKeyPrefix: "algorithm-a-cert",
+                    name: "shared-name"
+                )
+            )
+        )
+        let second = PublicKeyAlgorithmRegistration(
+            publicKey: TestRSAPublicKey.self,
+            signature: TestRSASHA512Signature.self,
+            userAuthenticationAlgorithm: .init(
+                name: "shared-name",
+                certificate: .init(
+                    publicKeyPrefix: "algorithm-b-cert",
+                    name: "algorithm-b-cert"
+                )
+            )
+        )
+
+        XCTAssertNil(NIOSSHAlgorithms.userAuthenticationAlgorithmBindings(for: [first, second]))
+        XCTAssertNil(NIOSSHAlgorithms.userAuthenticationAlgorithmBindings(for: [second, first]))
+    }
+
+    func testRegistrationAdapterChecksPlainAndCertificateAliasesAgainstBundledNames() {
+        let plainAlias = PublicKeyAlgorithmRegistration(
+            publicKey: TestRSAPublicKey.self,
+            signature: TestRSASHA256Signature.self,
+            userAuthenticationAlgorithm: .init(
+                name: "custom-auth",
+                aliases: ["ssh-ed25519"]
+            )
+        )
+        let certificateAlias = PublicKeyAlgorithmRegistration(
+            publicKey: TestRSAPublicKey.self,
+            signature: TestRSASHA256Signature.self,
+            userAuthenticationAlgorithm: .init(
+                name: "custom-auth",
+                certificate: .init(
+                    publicKeyPrefix: "custom-cert",
+                    name: "custom-cert-auth",
+                    aliases: ["ssh-ed25519-cert-v01@openssh.com"]
+                )
+            )
+        )
+
+        XCTAssertNil(NIOSSHAlgorithms.userAuthenticationAlgorithmBindings(for: [plainAlias]))
+        XCTAssertNil(NIOSSHAlgorithms.userAuthenticationAlgorithmBindings(for: [certificateAlias]))
+    }
+
+    func testAuthenticationNameMayBeReusedForTheExactSameBinding() throws {
+        let first = NamedUserAuthenticationAlgorithmBinding(
+            names: ["algorithm-a", "shared-name"],
+            binding: self.unrelatedBinding
+        )
+        let second = NamedUserAuthenticationAlgorithmBinding(
+            names: ["algorithm-b", "shared-name"],
+            binding: self.unrelatedBinding
+        )
+
+        let bindings = try XCTUnwrap(
+            NIOSSHAlgorithms.validatedUserAuthenticationAlgorithmBindings(customBindings: [first, second])
+        )
+        XCTAssertEqual(bindings["shared-name"], self.unrelatedBinding)
+        XCTAssertEqual(bindings["algorithm-a"], self.unrelatedBinding)
+        XCTAssertEqual(bindings["algorithm-b"], self.unrelatedBinding)
+    }
+
+    func testRSAAlgorithmsMaySharePublicKeyBlobFormats() throws {
+        let rsaBindings = [
+            NamedUserAuthenticationAlgorithmBinding(
+                names: ["rsa-sha2-256"],
+                binding: .init(
+                    publicKeyParser: .custom(ObjectIdentifier(PublicKeyParserA.self)),
+                    publicKeyPrefix: "ssh-rsa",
+                    publicKeyForm: .plain,
+                    signatureParser: .custom(ObjectIdentifier(SignatureParserA.self)),
+                    signaturePrefix: "rsa-sha2-256"
+                )
+            ),
+            NamedUserAuthenticationAlgorithmBinding(
+                names: ["rsa-sha2-512"],
+                binding: .init(
+                    publicKeyParser: .custom(ObjectIdentifier(PublicKeyParserA.self)),
+                    publicKeyPrefix: "ssh-rsa",
+                    publicKeyForm: .plain,
+                    signatureParser: .custom(ObjectIdentifier(SignatureParserB.self)),
+                    signaturePrefix: "rsa-sha2-512"
+                )
+            ),
+            NamedUserAuthenticationAlgorithmBinding(
+                names: ["rsa-sha2-256-cert-v01@openssh.com"],
+                binding: .init(
+                    publicKeyParser: .custom(ObjectIdentifier(PublicKeyParserA.self)),
+                    publicKeyPrefix: "ssh-rsa-cert-v01@openssh.com",
+                    publicKeyForm: .certificate,
+                    signatureParser: .custom(ObjectIdentifier(SignatureParserA.self)),
+                    signaturePrefix: "rsa-sha2-256"
+                )
+            ),
+            NamedUserAuthenticationAlgorithmBinding(
+                names: ["rsa-sha2-512-cert-v01@openssh.com"],
+                binding: .init(
+                    publicKeyParser: .custom(ObjectIdentifier(PublicKeyParserA.self)),
+                    publicKeyPrefix: "ssh-rsa-cert-v01@openssh.com",
+                    publicKeyForm: .certificate,
+                    signatureParser: .custom(ObjectIdentifier(SignatureParserB.self)),
+                    signaturePrefix: "rsa-sha2-512"
+                )
+            ),
+        ]
+
+        let bindings = try XCTUnwrap(
+            NIOSSHAlgorithms.validatedUserAuthenticationAlgorithmBindings(customBindings: rsaBindings)
+        )
+        XCTAssertEqual(bindings["rsa-sha2-256"]?.publicKeyPrefix, "ssh-rsa")
+        XCTAssertEqual(bindings["rsa-sha2-512"]?.publicKeyPrefix, "ssh-rsa")
+        XCTAssertEqual(
+            bindings["rsa-sha2-256-cert-v01@openssh.com"]?.publicKeyPrefix,
+            "ssh-rsa-cert-v01@openssh.com"
+        )
+        XCTAssertEqual(
+            bindings["rsa-sha2-512-cert-v01@openssh.com"]?.publicKeyPrefix,
+            "ssh-rsa-cert-v01@openssh.com"
+        )
+    }
+}

--- a/Tests/NIOSSHTests/UserAuthenticationStateMachineTests.swift
+++ b/Tests/NIOSSHTests/UserAuthenticationStateMachineTests.swift
@@ -144,12 +144,29 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
         // For signed methods we need to be a bit careful: we can't assume that the signature will have a bitwise match, so we have to validate it
         // instead.
-        if case .some(.publicKey(.known(let expectedKey, _))) = expectedMessage.map({ $0.method }),
-           case .some(.publicKey(.known(let actualKey, let actualSignature))) = request.map({ $0.method }),
+        if case .some(
+            .publicKey(
+                .known(
+                    authenticationAlgorithm: let expectedAlgorithm,
+                    key: let expectedKey,
+                    signature: _
+                )
+            )
+        ) = expectedMessage.map({ $0.method }),
+           case .some(
+            .publicKey(
+                .known(
+                    authenticationAlgorithm: let actualAlgorithm,
+                    key: let actualKey,
+                    signature: let actualSignature
+                )
+            )
+           ) = request.map({ $0.method }),
            let userAuthPayload = userAuthPayload
         {
             XCTAssertEqual(expectedMessage!.username, request!.username)
             XCTAssertEqual(expectedMessage!.service, request!.service)
+            XCTAssertEqual(expectedAlgorithm, actualAlgorithm)
             XCTAssertEqual(expectedKey, actualKey)
             XCTAssertTrue(expectedKey.isValidSignature(actualSignature!, for: userAuthPayload))
         } else {
@@ -174,12 +191,29 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
         // For signed methods we need to be a bit careful: we can't assume that the signature will have a bitwise match, so we have to validate it
         // instead.
-        if case .some(.publicKey(.known(let expectedKey, _))) = expectedMessage.map({ $0.method }),
-           case .some(.publicKey(.known(let actualKey, let actualSignature))) = request.map({ $0.method }),
+        if case .some(
+            .publicKey(
+                .known(
+                    authenticationAlgorithm: let expectedAlgorithm,
+                    key: let expectedKey,
+                    signature: _
+                )
+            )
+        ) = expectedMessage.map({ $0.method }),
+           case .some(
+            .publicKey(
+                .known(
+                    authenticationAlgorithm: let actualAlgorithm,
+                    key: let actualKey,
+                    signature: let actualSignature
+                )
+            )
+           ) = request.map({ $0.method }),
            let userAuthPayload = userAuthPayload
         {
             XCTAssertEqual(expectedMessage!.username, request!.username)
             XCTAssertEqual(expectedMessage!.service, request!.service)
+            XCTAssertEqual(expectedAlgorithm, actualAlgorithm)
             XCTAssertEqual(expectedKey, actualKey)
             XCTAssertTrue(expectedKey.isValidSignature(actualSignature!, for: userAuthPayload))
         } else {
@@ -704,7 +738,13 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
         stateMachine.sendUserAuthPKOK(response)
 
         // Now the user issues the actual query. This fails.
-        let payload = UserAuthSignablePayload(sessionIdentifier: self.sessionID, userName: "foo", serviceName: "ssh-connection", publicKey: self.hostKey.publicKey)
+        let payload = UserAuthSignablePayload(
+            sessionIdentifier: self.sessionID,
+            userName: "foo",
+            serviceName: "ssh-connection",
+            authenticationAlgorithm: String(self.hostKey.publicKey.keyPrefix),
+            publicKey: self.hostKey.publicKey
+        )
         let signature = try self.hostKey.sign(payload)
         let request = SSHMessage.UserAuthRequestMessage(username: "foo", service: "ssh-connection", method: .publicKey(.known(key: self.hostKey.publicKey, signature: signature)))
         try self.expectAuthRequestToFailSynchronously(request: request,
@@ -714,7 +754,13 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
         // Ok, let's do another query with a different key type. This time we won't bother with the little preamble dance, we'll just go straight to
         // querying: this should be fine too.
-        let payload2 = UserAuthSignablePayload(sessionIdentifier: self.sessionID, userName: "foo", serviceName: "ssh-connection", publicKey: newKey.publicKey)
+        let payload2 = UserAuthSignablePayload(
+            sessionIdentifier: self.sessionID,
+            userName: "foo",
+            serviceName: "ssh-connection",
+            authenticationAlgorithm: String(newKey.publicKey.keyPrefix),
+            publicKey: newKey.publicKey
+        )
         let newSignature = try newKey.sign(payload2)
         let request2 = SSHMessage.UserAuthRequestMessage(username: "foo", service: "ssh-connection", method: .publicKey(.known(key: newKey.publicKey, signature: newSignature)))
         try self.expectAuthRequestToSucceedSynchronously(request: request2, stateMachine: &stateMachine)
@@ -745,7 +791,13 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
         XCTAssertNoThrow(try self.beginAuthentication(stateMachine: &stateMachine))
         stateMachine.sendServiceRequest(.init(service: "ssh-userauth"))
 
-        let dataToSign = UserAuthSignablePayload(sessionIdentifier: self.sessionID, userName: "foo", serviceName: "ssh-connection", publicKey: delegate.key.publicKey)
+        let dataToSign = UserAuthSignablePayload(
+            sessionIdentifier: self.sessionID,
+            userName: "foo",
+            serviceName: "ssh-connection",
+            authenticationAlgorithm: String(delegate.key.publicKey.keyPrefix),
+            publicKey: delegate.key.publicKey
+        )
         let signature = try delegate.key.sign(dataToSign)
         let firstMessage = SSHMessage.UserAuthRequestMessage(username: "foo", service: "ssh-connection", method: .publicKey(.known(key: delegate.key.publicKey, signature: signature)))
         XCTAssertNoThrow(try self.serviceAccepted(service: "ssh-userauth", nextMessage: firstMessage, userAuthPayload: dataToSign, stateMachine: &stateMachine))
@@ -767,7 +819,14 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
         XCTAssertNoThrow(try self.beginAuthentication(stateMachine: &stateMachine))
         stateMachine.sendServiceRequest(.init(service: "ssh-userauth"))
 
-        let dataToSign = UserAuthSignablePayload(sessionIdentifier: self.sessionID, userName: "foo", serviceName: "ssh-connection", publicKey: NIOSSHPublicKey(delegate.certifiedKey))
+        let certifiedKey = NIOSSHPublicKey(delegate.certifiedKey)
+        let dataToSign = UserAuthSignablePayload(
+            sessionIdentifier: self.sessionID,
+            userName: "foo",
+            serviceName: "ssh-connection",
+            authenticationAlgorithm: String(certifiedKey.keyPrefix),
+            publicKey: certifiedKey
+        )
         let signature = try delegate.privateKey.sign(dataToSign)
 
         let firstMessage = SSHMessage.UserAuthRequestMessage(username: "foo", service: "ssh-connection", method: .publicKey(.known(key: NIOSSHPublicKey(delegate.certifiedKey), signature: signature)))


### PR DESCRIPTION
This builds on #10 to support RSA certificates for SSH user authentication when RSA is provided through NIOSSH’s custom-key APIs.

RSA SHA-2 certificate authentication uses different identifiers for each layer of a public-key request. For example, RSA SHA-256 certificate authentication uses:

- `rsa-sha2-256-cert-v01@openssh.com` as the user-authentication algorithm
- `ssh-rsa-cert-v01@openssh.com` as the certificate public-key format
- `rsa-sha2-256` as the signature algorithm

Previously, NIOSSH derived the user-authentication algorithm from the public-key blob prefix and effectively paired each custom public-key type with one signature parser. That model could not represent RSA SHA-2 certificates, whose request, certificate-key, and signature identifiers differ.

This PR provides the protocol and registration support required by custom RSA implementations. It does not add a built-in RSA key implementation to NIOSSH.

### Changes

- Added `NIOSSHUserAuthenticationAlgorithm` to describe canonical user-authentication names, aliases, and certificate-specific authentication and public-key formats.
- Added `NIOSSHAlgorithms.register(publicKey:signature:userAuthenticationAlgorithm:)` to associate a custom public-key parser and signature parser with their user-authentication identifiers.
- Allowed `rsa-sha2-256` and `rsa-sha2-512` registrations to share the same `ssh-rsa` public-key format and `ssh-rsa-cert-v01@openssh.com` certificate format.
- Preserved the selected authentication algorithm through `SSH_MSG_USERAUTH_REQUEST`, `SSH_MSG_USERAUTH_PK_OK`, payload signing, parsing, and server-side verification.
- Corrected custom certificate serialization so only the algorithm-specific public-key body is written after the certificate prefix. This prevents an additional `ssh-rsa` identifier from being embedded before the RSA exponent and modulus.
- Added consistency checks between the authentication algorithm, key format, plain or certificate form, and signature algorithm.
- Rejected trailing data in known public-key and signature blobs parsed from `SSH_MSG_USERAUTH_REQUEST` and `SSH_MSG_USERAUTH_PK_OK`.
- Included the signature prefix in custom signature equality and hashing.

### Custom-Key API

- Added `userAuthenticationAlgorithmIdentifier` to `NIOSSHPrivateKeyProtocol`, allowing a custom private key to select its registered user-authentication algorithm independently from its public-key format.
- Added `userAuthenticationSignature(for:)`, allowing custom keys to use a user-authentication signature algorithm that differs from their host-key signing algorithm.
- Provided default implementations for both requirements:
  - The authentication identifier defaults to `publicKey.publicKeyPrefix`.
  - User-authentication signing defaults to the existing `signature(for:)` implementation.
- Preserved the existing `NIOSSHAlgorithms.register(publicKey:signature:)` overload, which continues to use the public-key prefix as the authentication name.

### Compatibility

Existing one-to-one custom registrations and private-key protocol conformers remain source-compatible through the existing registration overload and default protocol implementations.

Valid existing Ed25519 and ECDSA authentication flows remain supported. Repeated identical registrations are idempotent, while conflicting or ambiguous authentication and signature registrations now fail with a precondition.

Custom certified keys must be registered with a certificate-capable authentication mapping before they can be constructed or decoded.

Certificate validity comparisons now use `Date` and `UInt64` instead of platform-specific `DispatchWallTime` and `time_t` conversions. Newer `Sendable` declarations are also guarded for Swift 5.4 compatibility.

### Downstream Validation

These changes were validated locally with Citadel using a SwiftPM path dependency pointing to this branch. With this version of NIOSSH, Citadel’s RSA key implementation can perform RSA certificate authentication successfully.

The corresponding Citadel dependency update and RSA certificate authentication changes will be submitted after this PR is merged.

### Testing

Added 22 tests in total:

- 21 unit tests covering:
  - Canonical RSA certificate wire encoding
  - RSA SHA-256 and SHA-512 registration and framing
  - Plain and certified RSA request round trips
  - Public-key probes and `SSH_MSG_USERAUTH_PK_OK`
  - Authentication, key, and signature mismatch rejection
  - Registration aliases, collisions, and compatibility defaults
  - Server state-machine certificate validation and registered-signature verification
- One macOS OpenSSH interoperability test

When `ssh-keygen`, `sshd`, `nc`, and `openssl` are available, the interoperability test generates an RSA key and user certificate, starts a local OpenSSH server, and authenticates a SwiftNIO SSH client using `rsa-sha2-256-cert-v01@openssh.com`.

On macOS, `swift test --explicit-target-dependency-import-check error` passes all 377 tests, including the OpenSSH interoperability test.

The interoperability test exercises real RSA SHA-256 signing and authentication. RSA SHA-512 is covered at the registration, request framing, round-trip parsing, and mismatch-rejection levels.